### PR TITLE
feat: pull-sync catalog-source loaders (@ratel-ai/cloud, ratel-ai-cloud) + SDK source seam

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,3 +78,33 @@ jobs:
       - name: Run the telemetry example
         working-directory: examples/telemetry-python
         run: uv run --python 3.11 main.py
+
+  # Cloud catalog-source loader (ADR-0003): pure Python, but it hydrates a
+  # ratel_ai.SkillCatalog, so the SDK's native extension is maturin-built into a
+  # shared venv first (mirrors the documented local dev flow in its README).
+  cloud:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/sdk/cloud-py
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/sdk/python/native
+      - uses: astral-sh/setup-uv@v5
+      - name: Build ratel-ai (native extension) into the shared venv
+        working-directory: src/sdk/python
+        run: |
+          uv venv --python 3.11 .venv
+          uv pip install --python .venv maturin
+          .venv/bin/maturin develop
+      - name: Install (editable) + dev tools
+        run: uv pip install --python ../python/.venv -e '.[dev]'
+      - name: Lint
+        run: ../python/.venv/bin/ruff check .
+      - name: Typecheck
+        run: ../python/.venv/bin/mypy ratel_ai_cloud
+      - name: Test
+        run: ../python/.venv/bin/pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ name: Release
 #   telemetry-ts-otlp-v* -> @ratel-ai/telemetry-otlp on npm (the init() exporter)
 #     The telemetry helpers release independently (one registry each; otlp is the
 #     npm exporter split from the vocabulary); tag the same commit to ship together.
+#   cloud-ts-v*       -> @ratel-ai/cloud on npm (catalog-source loader, ADR-0003)
+#   cloud-py-v*       -> ratel-ai-cloud on PyPI (catalog-source loader, ADR-0003)
+#     The cloud loaders release independently of their language SDKs (dependency
+#     ranges, not lockstep).
 
 on:
   push:
@@ -25,6 +29,8 @@ on:
       - 'telemetry-ts-v*'
       - 'telemetry-py-v*'
       - 'telemetry-ts-otlp-v*'
+      - 'cloud-ts-v*'
+      - 'cloud-py-v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -584,6 +590,112 @@ jobs:
             (cd src/telemetry/ts-otlp && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
           fi
 
+  # The cloud loaders (ADR-0003) are independent single-registry units on their own
+  # tag prefixes (cloud-ts-v* / cloud-py-v*), each with its own Trusted Publisher.
+  publish-cloud-ts:
+    name: Publish @ratel-ai/cloud to npm
+    needs: [tag-version-check]
+    if: needs.tag-version-check.outputs.unit == 'cloud-ts'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+      # The loader is pure TS, but building its @ratel-ai/sdk workspace dependency
+      # (for the .d.ts surface) runs the SDK's napi typegen, which compiles the
+      # native crate — hence the Rust toolchain.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/sdk/ts/native
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Verify npm CLI version
+        shell: bash
+        run: |
+          set -e
+          npm --version
+          # Trusted Publishers requires npm CLI 11.5.1+
+          node -e "const v = require('child_process').execSync('npm --version').toString().trim(); const [maj, min, patch] = v.split('.').map(Number); if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) { console.error('npm CLI ' + v + ' < 11.5.1 (required for Trusted Publishers)'); process.exit(1); } console.log('npm ' + v + ' OK');"
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      # Build the loader and its @ratel-ai/sdk workspace dependency (topo order).
+      - name: Build TS
+        run: pnpm --filter "@ratel-ai/cloud..." run build
+      # npm keeps `workspace:` specifiers verbatim, so pin the dep to the concrete
+      # released @ratel-ai/sdk version before publishing (ephemeral CI edit; not
+      # committed). Keeps the npm-OIDC dir publish + provenance identical to the
+      # other units rather than switching to `pnpm publish`.
+      - name: Pin the @ratel-ai/sdk dependency for publish
+        shell: bash
+        run: |
+          set -e
+          sdk_ver=$(node -p "require('./src/sdk/ts/package.json').version")
+          SDK_VER="$sdk_ver" node -e "const fs=require('fs'); const f='./src/sdk/cloud/package.json'; const p=require(f); p.dependencies['@ratel-ai/sdk']='^'+process.env.SDK_VER; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')"
+          echo "pinned @ratel-ai/sdk -> $(node -p "require('./src/sdk/cloud/package.json').dependencies['@ratel-ai/sdk']")"
+      # Preflight dry-run BEFORE the real (immutable) publish, mirroring the SDK job.
+      - name: Preflight — dry-run npm publish
+        shell: bash
+        env:
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: (cd src/sdk/cloud && npm publish --access public --tag "$DIST_TAG" --dry-run)
+      - name: Publish
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          DIST_TAG: ${{ needs.tag-version-check.outputs.dist_tag }}
+        run: |
+          set -e
+          name=$(node -p "require('./src/sdk/cloud/package.json').name")
+          ver=$(node -p "require('./src/sdk/cloud/package.json').version")
+          # Idempotent: skip if this exact name@version is already live (npm is immutable).
+          if [ -z "$DRY_RUN" ] && [ "$(npm view "$name@$ver" version 2>/dev/null)" = "$ver" ]; then
+            echo "::notice::$name@$ver already published — skipping"
+          else
+            (cd src/sdk/cloud && npm publish --provenance --access public --tag "$DIST_TAG" $DRY_RUN)
+          fi
+
+  publish-cloud-py:
+    name: Publish ratel-ai-cloud to PyPI
+    needs: [tag-version-check]
+    if: needs.tag-version-check.outputs.unit == 'cloud-py'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # Trusted Publishing (OIDC) — no PyPI token stored as a secret.
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # Pure-python (hatchling): one universal py3-none-any wheel + sdist, no matrix.
+      - name: Build wheel + sdist
+        run: |
+          set -e
+          python -m pip install --upgrade build 'packaging>=24.2' twine
+          python -m build --outdir "$PWD/dist" src/sdk/cloud-py
+      - name: Validate packaging (metadata + README rendering)
+        run: twine check dist/*
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+        # Dry runs upload nothing; gate on the workflow_dispatch flag.
+        if: ${{ !inputs.dry_run }}
+
   github-release:
     name: GitHub Release
     needs:
@@ -595,6 +707,8 @@ jobs:
       - publish-telemetry-py
       - publish-telemetry-core
       - publish-telemetry-ts-otlp
+      - publish-cloud-ts
+      - publish-cloud-py
     # Exactly one unit's publish job runs; the rest are skipped. Run when the tag
     # was pushed and that one job succeeded. Every unit is single-registry now, so
     # any one publish job succeeding is enough.
@@ -607,7 +721,9 @@ jobs:
               || needs.publish-telemetry-ts.result == 'success'
               || needs.publish-telemetry-py.result == 'success'
               || needs.publish-telemetry-core.result == 'success'
-              || needs.publish-telemetry-ts-otlp.result == 'success') }}
+              || needs.publish-telemetry-ts-otlp.result == 'success'
+              || needs.publish-cloud-ts.result == 'success'
+              || needs.publish-cloud-py.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -1,8 +1,9 @@
 name: Verify install
 
 # Per-unit install smoke tests (ADR-0008). Each release unit — core (crate),
-# sdk-ts (npm), sdk-py (PyPI), and the four telemetry units (telemetry-core on
-# crates.io, telemetry-ts + telemetry-ts-otlp on npm, telemetry-py on PyPI) — is verified from its
+# sdk-ts (npm), sdk-py (PyPI), the four telemetry units (telemetry-core on
+# crates.io, telemetry-ts + telemetry-ts-otlp on npm, telemetry-py on PyPI), and
+# the two cloud loaders (cloud-ts on npm, cloud-py on PyPI) — is verified from its
 # public registry with no repo checkout and no local toolchain state, so a broken
 # publish surfaces here.
 #
@@ -16,7 +17,7 @@ on:
         description: Release unit to verify
         type: choice
         default: all
-        options: [all, core, sdk-ts, sdk-py, telemetry-core, telemetry-ts, telemetry-py, telemetry-ts-otlp]
+        options: [all, core, sdk-ts, sdk-py, telemetry-core, telemetry-ts, telemetry-py, telemetry-ts-otlp, cloud-ts, cloud-py]
       version:
         description: Version to verify (e.g. 0.2.0-rc.2 or 0.2.0). Only applied when a single unit is selected; ignored for `all`.
         required: false
@@ -263,6 +264,94 @@ jobs:
           }
           EOF
           cargo run -q
+
+  # The cloud loaders are pure-language, so one linux leg each. Installing them
+  # pulls the language SDK (and its native binding) from the registry, so the
+  # smoke test proves cross-package resolution too: it runs a real pull-sync
+  # against the packaged in-process mock source and reads the synced skill back
+  # out of the hydrated catalog.
+  verify-cloud-ts:
+    name: verify cloud-ts (npm)
+    if: github.event_name == 'schedule' || inputs.unit == 'all' || inputs.unit == 'cloud-ts'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          set -e
+          if [ "${{ inputs.unit }}" = "cloud-ts" ] && [ -n "${{ inputs.version }}" ]; then
+            echo "spec=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "spec=${{ inputs.tag || 'latest' }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install + smoke-test the package
+        shell: bash
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          cd "$tmp"
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund "@ratel-ai/cloud@${{ steps.ver.outputs.spec }}"
+          cat > smoke.mjs <<'EOF'
+          import { SkillCatalog } from "@ratel-ai/sdk";
+          import { syncSkills } from "@ratel-ai/cloud";
+          import { startMockSource } from "@ratel-ai/cloud/testing";
+
+          const source = await startMockSource({ apiKey: "verify-key" });
+          source.setSkills([{ id: "s1", name: "verify", description: "verify install", tags: [], tools: [], metadata: {}, body: "# ok" }]);
+          const catalog = new SkillCatalog();
+          const result = await syncSkills(catalog, { url: source.url, apiKey: "verify-key", env: {} });
+          await source.close();
+          if (result.added !== 1 || catalog.invoke("s1") !== "# ok") {
+            console.error("sync failed", result);
+            process.exit(1);
+          }
+          console.log("OK", result);
+          EOF
+          node smoke.mjs
+
+  verify-cloud-py:
+    name: verify cloud-py (PyPI)
+    if: github.event_name == 'schedule' || inputs.unit == 'all' || inputs.unit == 'cloud-py'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Resolve spec
+        id: ver
+        shell: bash
+        run: |
+          set -e
+          if [ "${{ inputs.unit }}" = "cloud-py" ] && [ -n "${{ inputs.version }}" ]; then
+            echo "spec===${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "spec=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install + smoke-test the package
+        shell: bash
+        run: |
+          set -e
+          python -m pip install --upgrade pip
+          python -m pip install "ratel-ai-cloud${{ steps.ver.outputs.spec }}"
+          python - <<'EOF'
+          from ratel_ai import SkillCatalog
+          from ratel_ai_cloud import sync_skills
+          from ratel_ai_cloud.testing.mock_source import MockSource
+
+          skill = {"id": "s1", "name": "verify", "description": "verify install",
+                   "tags": [], "tools": [], "metadata": {}, "body": "# ok"}
+          with MockSource(api_key="verify-key") as src:
+              src.set_skills([skill])
+              catalog = SkillCatalog()
+              result = sync_skills(catalog, url=src.url, api_key="verify-key", env={})
+          assert result.added == 1 and catalog.invoke("s1") == "# ok", result
+          print("OK", result)
+          EOF
 
   verify-telemetry-ts-otlp:
     name: verify telemetry-ts-otlp (npm)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 How a new version of a Ratel package is published. Read end-to-end before cutting a release.
 
-Ratel releases **per unit** (ADR-0008): seven independently-versioned release units, each on
+Ratel releases **per unit** (ADR-0008): nine independently-versioned release units, each on
 its own tag prefix, all routed through one `release.yml`. There is no workspace-shared
 version — each unit carries its own version in its own manifest and ships on its own cadence.
 
@@ -17,6 +17,8 @@ version — each unit carries its own version in its own manifest and ships on i
 | `telemetry-ts` | `telemetry-ts-v*` | `@ratel-ai/telemetry` on npm | `src/telemetry/ts/package.json` |
 | `telemetry-py` | `telemetry-py-v*` | `ratel-ai-telemetry` on PyPI | `src/telemetry/python/pyproject.toml` |
 | `telemetry-ts-otlp` | `telemetry-ts-otlp-v*` | `@ratel-ai/telemetry-otlp` on npm | `src/telemetry/ts-otlp/package.json` |
+| `cloud-ts` | `cloud-ts-v*` | `@ratel-ai/cloud` on npm | `src/sdk/cloud/package.json` |
+| `cloud-py` | `cloud-py-v*` | `ratel-ai-cloud` on PyPI | `src/sdk/cloud-py/pyproject.toml` |
 
 The units are registered once, in [`scripts/release-units.mjs`](scripts/release-units.mjs)
 — the single source of truth that the tag gate, the `releasable` helper, the changelog
@@ -37,12 +39,20 @@ to release them in one run. `telemetry-ts-otlp` (`@ratel-ai/telemetry-otlp` → 
 time. All four are pure-language, so the manual helper builds them locally (no prebuilt
 artifacts).
 
+The two **cloud** units are the catalog-source loaders (ADR-0003): `cloud-ts`
+(`@ratel-ai/cloud` → npm) and `cloud-py` (`ratel-ai-cloud` → PyPI). Each depends on its
+language SDK by version range (`@ratel-ai/sdk` / `ratel-ai`), not lockstep, so a loader fix
+ships alone. Both are pure-language; the manual helper builds them locally (`cloud-ts`
+additionally compiles the `@ratel-ai/sdk` workspace dependency, which needs a Rust toolchain
+for its napi typegen).
+
 `@ratel-ai/mcp-server` ships from a sibling repo, [ratel-ai/ratel-mcp](https://github.com/ratel-ai/ratel-mcp), on its own cadence.
 
 ## How the release pipeline is wired
 
 - **`release.yml`** — fires on any `core-v*` / `sdk-ts-v*` / `sdk-py-v*` / `telemetry-core-v*` /
-  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` tag push (and
+  `telemetry-ts-v*` / `telemetry-py-v*` / `telemetry-ts-otlp-v*` / `cloud-ts-v*` /
+  `cloud-py-v*` tag push (and
   supports `workflow_dispatch` with `dry_run: true` for rehearsal). Its first job,
   `tag-version-check`, runs [`scripts/check-release-tag.mjs`](scripts/check-release-tag.mjs) to
   route the tag to its unit and verify **only that unit's** manifests + CHANGELOG carry the
@@ -115,14 +125,16 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
   `ratel-ai-core` crate, and the `ratel-ai` PyPI project — each pointing at this repo /
   `release.yml` / the `release` environment. **The 4 telemetry names
   (`@ratel-ai/telemetry` + `@ratel-ai/telemetry-otlp` on npm, `ratel-ai-telemetry` on PyPI +
-  crates.io) are not yet registered** — they are added at their first-time bootstrap, taking
-  the total 8 → 12.
+  crates.io) and the 2 cloud loader names (`@ratel-ai/cloud` on npm, `ratel-ai-cloud` on
+  PyPI) are not yet registered** — they are added at their first-time bootstrap, taking the
+  total 8 → 14.
 - A `release` GitHub Environment exists whose **deployment tag policy allows the unit
   prefixes** — `core-v*`, `sdk-ts-v*`, `sdk-py-v*`. Keep the environment *name* `release`
   unchanged (it's what binds the Trusted Publishers); only its tag policy lists the prefixes.
   A tag not matched by the policy hangs the publish job at the deploy gate. **Add
   `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*` to the policy
-  before cutting the first telemetry release** (still pending).
+  before cutting the first telemetry release, and `cloud-ts-v*`, `cloud-py-v*` before the
+  first cloud loader release** (still pending).
 
 ### Per-release flow (one unit at a time)
 
@@ -140,6 +152,8 @@ rstagi with a one-member team. Run the E2E locally per `e2e/README.md`.
    - `telemetry-py` → `src/telemetry/python/pyproject.toml` (PEP 440 spelling, e.g. `0.1.0rc1`).
    - `telemetry-ts-otlp` → `src/telemetry/ts-otlp/package.json`.
      The four telemetry units version independently; bump only the one(s) you are releasing.
+   - `cloud-ts` → `src/sdk/cloud/package.json`.
+   - `cloud-py` → `src/sdk/cloud-py/pyproject.toml` (PEP 440 spelling, e.g. `0.1.0rc1`).
 3. **Update the CHANGELOG:** run the `/changelog` skill (`.claude/skills/changelog/`) for
    `$UNIT`. It drafts entries with [git-cliff](https://git-cliff.org) scoped to the unit,
    lets you curate, and writes the unit's `CHANGELOG.md`. For GA versions (no `-rc` suffix) it
@@ -196,16 +210,20 @@ Publishers can't be configured for a package that doesn't exist yet. Do this per
    - `telemetry-core` / `telemetry-ts` / `telemetry-py` / `telemetry-ts-otlp` need no prebuilt
      artifact — they are pure-language, so `publish-rc.sh` builds the crate, the two npm
      packages, and the wheel/sdist locally.
+   - `cloud-ts` / `cloud-py` likewise build locally (`cloud-ts` needs a Rust toolchain for
+     the `@ratel-ai/sdk` dependency's napi typegen; `cloud-py` needs `pip install build twine`).
 2. Log in locally: `npm login` (npm requires 2FA on the publishing account for a first-publish
    of scoped public packages), `cargo login` for crates.io, and configure twine credentials
    (`TWINE_USERNAME=__token__` + a PyPI token, or `~/.pypirc`) for PyPI. The four telemetry
    units together need all three registries (`telemetry-ts` + `telemetry-ts-otlp` → npm,
    `telemetry-py` → PyPI, `telemetry-core` → crates.io); also `pip install build twine`.
 3. Run `scripts/publish-rc.sh --unit <unit> --from-run <run-id>` (omit `--from-run` for
-   `core` and the telemetry units). It reads the unit's version from its manifest, finds the
-   tarballs/wheels in the run's artifacts, and publishes — npm subpackages → loader for
-   `sdk-ts`, `twine upload --skip-existing` for `sdk-py`, `cargo publish` for `core`, and the
-   locally-built npm / npm / wheel / crate for `telemetry-ts` / `telemetry-ts-otlp` / `telemetry-py` / `telemetry-core`.
+   `core`, the telemetry units, and the cloud units). It reads the unit's version from its
+   manifest, finds the tarballs/wheels in the run's artifacts, and publishes — npm
+   subpackages → loader for `sdk-ts`, `twine upload --skip-existing` for `sdk-py`,
+   `cargo publish` for `core`, and locally-built artifacts for the telemetry and cloud units
+   (`telemetry-ts` / `telemetry-ts-otlp` / `cloud-ts` → npm, `telemetry-py` / `cloud-py` →
+   PyPI, `telemetry-core` → crates.io).
    It's idempotent (skips anything already on the registry), so a partial failure is safe to
    resume. First-publish from a laptop ships **without provenance** (that requires GH Actions
    OIDC); that's expected for the bootstrap.

--- a/docs/adr/0003-catalog-source-interface.md
+++ b/docs/adr/0003-catalog-source-interface.md
@@ -11,6 +11,9 @@ auth and scope), and ADR-0021 (sync and storage), all 2026-07-05. The scope mode
 originally carried is split out to [ADR-0010](0010-catalog-scope-model.md) (Proposed); the
 loader interface, auth, and sync semantics recorded here are accepted.
 
+Amended 2026-07-07 with the shipped SDK loader-seam decisions: attach API, catalog ownership
+and mutation shape, `RATEL_API_KEY`, per-scope caching, in-memory replica.
+
 ## Context
 
 An earlier plan scheduled a standalone `ratel-ai-server` binary as the rung between the
@@ -42,6 +45,19 @@ implementation of the already-published contract, not a new design.
   Application code does not change ([ADR-0002](0002-product-split-engine-local-cloud.md)).
 - Additional sources (a local file/dir loader, git, a self-hosted endpoint) are added as
   loaders when a use case appears.
+- A loader attaches as a **free function returning a handle** (`createSkillSync(catalog)` /
+  `create_skill_sync(catalog)`), mirroring `registerMcpServer` / `register_mcp_server`: the
+  caller owns the network lifecycle and catalog construction is coupled to no source.
+  `syncSkills` / `sync_skills` is the one-shot variant (throws on failure); the handle
+  variant is offline-tolerant.
+- **Ownership rule:** a loader owns exactly the ids it synced. A host-registered skill with a
+  colliding id is never clobbered; the collision is surfaced in `SyncResult.conflicts`.
+- Hydration applies **per-id upsert/remove** diffs to the shared registries, not a snapshot
+  replace — the in-process floor and synced skills coexist in one catalog, which a snapshot
+  swap would clobber. Equality is field-wise over exactly the seven wire fields (the same set
+  the ETag projects), so resyncing identical data emits zero churn. Any remove, or an upsert
+  that replaces, invalidates the registry's dense cache in full (re-embedded on next use);
+  the BM25 path builds per call and is unaffected.
 
 ### The wire contract
 
@@ -67,13 +83,18 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
   column is not carried forward.
 - **Wire contract:** `Authorization: Bearer <key>` on every `/v1` request; missing/unknown/
   revoked → `401`, key store unreachable → `503`; TLS required.
+- **Client-side configuration:** `RATEL_API_KEY` is the companion env var to `RATEL_URL` and
+  carries the Bearer key. Explicit loader options beat the environment; resolution is a pure
+  function with an injectable env.
 - **Scope.** The served catalog is **scoped**: a project Bearer key authorizes a project, and
   an optional `?scope=<subject>` selector picks a subject layer within it. The scope model —
   the `tenant → project → subject` hierarchy, the overlay semantics, and the
   confidential-isolation policy — is [ADR-0010](0010-catalog-scope-model.md) (Proposed); the
   wire mechanics of the `?scope=` selector are frozen in
   [`protocol/v1`](../../protocol/v1/README.md). The engine stays scope-blind; the source
-  serves an already-scoped set.
+  serves an already-scoped set. Loader-side, scope is **fixed per loader instance** and
+  passed through opaquely; the ETag cache is keyed per `(url, scope)`, so a tag never
+  carries across scopes.
 - **Two credentials, never conflated:** the source API key (this contract) and upstream OAuth
   tokens (`~/.ratel/oauth/`, owned by ratel-local, used by locally-run `invoke_tool` to reach
   upstream MCP tools). The source never sees either side's other credential.
@@ -93,10 +114,16 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
   write path, deferred (PSKS-8, internal tracker), so there is no offline-write/merge class.
 - Secrets-never-sync is enforced **structurally**: no wire shape has a field that can carry a
   token, and a test fails if a secret-typed field enters a wire payload.
-- Offline: the client keeps the last-pulled catalog and runs degraded but functional;
-  staleness is unbounded and should be surfaced. `RATEL_URL` unset is the permanent offline
-  floor. Nothing moves off `~/.ratel/*`: config and oauth stay in ratel-local, so the pivot
-  deletes the mass re-auth risk a server port would have carried.
+- Offline: the replica is **in-memory only** — the client keeps the last-pulled catalog and
+  runs degraded but functional; a fresh process with an unreachable source starts on the
+  floor. Staleness is unbounded and surfaced on the loader handle (`lastSyncedAt` /
+  `consecutiveFailures`); a disk cache is deferred until a use case demands one.
+  `RATEL_URL` unset is the permanent offline floor. Nothing moves off `~/.ratel/*`: config
+  and oauth stay in ratel-local, so the pivot deletes the mass re-auth risk a server port
+  would have carried.
+- Loader-side ETag recomputation (re-deriving the hash from a returned `skills` set) is a
+  **test-only** conformance check against the vectors and the live source; at runtime the
+  wire ETag is authoritative.
 
 ### Deferred, explicitly
 
@@ -114,6 +141,10 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
 - A leaked key table yields no usable credential (hash-only storage).
 - The only server-side implementer today is the closed cloud; the conformance vectors are
   what keep the contract from silently becoming whatever the cloud does.
+- Per-id diffs keep the floor and a synced catalog in one registry; the cost is a full
+  dense-cache re-embed on churn under semantic/hybrid retrieval, accepted until finer
+  invalidation earns its complexity. Id conflicts are reported on every sync, never
+  silently resolved.
 
 ## Rejected
 
@@ -123,6 +154,11 @@ explicit decision; `@ratel-ai/cloud` is also the developer's tap into those.
   the insurance policy for the catalog rung.
 - **Bidirectional sync:** adds an offline-merge class and an upward path a secret could leak
   through; authoring is a separate explicit write path instead.
+- **Snapshot-replace hydration:** replacing the registry wholesale would clobber
+  host-registered (floor) skills; the ownership rule needs per-id upsert/remove.
+- **Constructor-coupled loaders:** a source option on the catalog constructor would tie
+  catalog construction to a network lifecycle; the free-function + handle shape keeps them
+  independent and symmetric across languages.
 - **KDF-hashed keys / mTLS:** adds weight where a 192-bit random token needs none; a lost
   key is rotated, not brute-forced. (The scope-model alternatives — per-subject keys as the
   default, confidential isolation — are weighed in [ADR-0010](0010-catalog-scope-model.md).)

--- a/docs/adr/0005-first-class-skills.md
+++ b/docs/adr/0005-first-class-skills.md
@@ -8,6 +8,9 @@ Accepted
 
 Compacted 2026-07 from pre-compaction ADR-0012 (first-class skills, 2026-06-09).
 
+Amended 2026-07-07: capability-tool advertising is dynamic — computed at read time from the
+live catalog — so asynchronously hydrated catalogs surface without re-registration.
+
 ## Context
 
 The gateway's wedge is tool selection; skills (SKILL.md playbooks: YAML frontmatter carrying
@@ -37,6 +40,12 @@ the only loader.
 - **`invoke_tool(toolId, args)`** runs a tool.
 - **`get_skill_content(skillId)`** returns `{ body }`; registered only when the skill catalog
   is non-empty.
+- **Dynamic advertising:** what the capability tools tell the model about themselves — the
+  `search_capabilities` description, whether it mentions the skills bucket and
+  `get_skill_content` — is computed at **read time** from the live catalog, never baked at
+  construction. A catalog hydrated after startup (a source loader pulling mid-session,
+  [ADR-0003](0003-catalog-source-interface.md)) is visible to the model on its next read of
+  the tool list; an emptied catalog stops advertising skills the same way.
 
 The agent must search to find a load-bearing tool, so bundling skills into that same response
 means the tool's necessity carries the skill: more reliable than a separate, skippable

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,25 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  src/sdk/cloud:
+    dependencies:
+      '@ratel-ai/sdk':
+        specifier: workspace:^
+        version: link:../ts
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.13
+        version: 2.4.13
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0))
+
   src/sdk/ts:
     dependencies:
       '@modelcontextprotocol/sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'src/sdk/ts'
+  - 'src/sdk/cloud'
   - 'src/telemetry/ts'
   - 'src/telemetry/ts-otlp'
   - 'examples/*'

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Per-unit release-tag gate (ADR-0008). A release is cut by pushing a prefixed
 // tag — one of the registered unit prefixes (`core-v*`, `sdk-ts-v*`, `sdk-py-v*`,
-// `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*`;
+// `telemetry-core-v*`, `telemetry-ts-v*`, `telemetry-py-v*`, `telemetry-ts-otlp-v*`,
+// `cloud-ts-v*`, `cloud-py-v*`;
 // the set is derived from release-units.mjs, not hard-coded here). This checks that ONLY the tagged
 // unit's manifests carry the tag's version and that its CHANGELOG(s) record it —
 // nothing else in the repo has to be in lockstep.

--- a/scripts/check-release-tag.test.mjs
+++ b/scripts/check-release-tag.test.mjs
@@ -45,6 +45,11 @@ function makeRepo(version = "0.2.0", pyVersion = version) {
   // telemetry-ts-otlp: the npm exporter unit, split from the vocabulary package.
   write("src/telemetry/ts-otlp/package.json", json("@ratel-ai/telemetry-otlp"));
   write("src/telemetry/ts-otlp/CHANGELOG.md", changelog(version));
+  // cloud loaders: two independent single-registry units (npm / PyPI), one per language.
+  write("src/sdk/cloud/package.json", json("@ratel-ai/cloud"));
+  write("src/sdk/cloud/CHANGELOG.md", changelog(version));
+  write("src/sdk/cloud-py/pyproject.toml", `[project]\nname = "ratel-ai-cloud"\nversion = "${pyVersion}"\n`);
+  write("src/sdk/cloud-py/CHANGELOG.md", changelog(version));
 
   return { root, write, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
@@ -58,6 +63,9 @@ test("parseTag splits prefix and version for every unit", () => {
   assert.deepEqual(parseTag("telemetry-ts-v0.1.0"), { unit: "telemetry-ts", version: "0.1.0" });
   assert.deepEqual(parseTag("telemetry-py-v0.2.0-rc.2"), { unit: "telemetry-py", version: "0.2.0-rc.2" });
   assert.deepEqual(parseTag("telemetry-ts-otlp-v0.1.0-rc.3"), { unit: "telemetry-ts-otlp", version: "0.1.0-rc.3" });
+  // the cloud loaders are independent units, one per language (npm / PyPI).
+  assert.deepEqual(parseTag("cloud-ts-v0.1.0-rc.1"), { unit: "cloud-ts", version: "0.1.0-rc.1" });
+  assert.deepEqual(parseTag("cloud-py-v0.1.0"), { unit: "cloud-py", version: "0.1.0" });
 });
 
 test("parseTag rejects the old lockstep tag and unknown prefixes", () => {
@@ -230,6 +238,43 @@ test("the three telemetry vocabulary units release independently — one's tag i
     repo.write("src/telemetry/core/CHANGELOG.md", "# Changelog\n\n## [0.0.9] - 2026-07-04\n\n### Added\n- thing\n");
     const core = checkReleaseTag("telemetry-core-v0.0.9", { root: repo.root });
     assert.equal(core.ok, true, core.errors.join("; "));
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("cloud-ts rc tag passes when the npm loader package + its changelog match", () => {
+  const repo = makeRepo("0.1.0-rc.1");
+  try {
+    const r = checkReleaseTag("cloud-ts-v0.1.0-rc.1", { root: repo.root });
+    assert.equal(r.ok, true, r.errors.join("; "));
+    assert.equal(r.unit, "cloud-ts");
+    assert.equal(r.distTag, "rc");
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("cloud-ts releases independently of its @ratel-ai/sdk dependency's version", () => {
+  // The SDK sits on a different version — a cloud loader release must not be
+  // blocked by it (the dependency is a range, not lockstep).
+  const repo = makeRepo("0.1.0");
+  try {
+    repo.write("src/sdk/ts/package.json", JSON.stringify({ name: "@ratel-ai/sdk", version: "0.3.0" }, null, 2));
+    const r = checkReleaseTag("cloud-ts-v0.1.0", { root: repo.root });
+    assert.equal(r.ok, true, r.errors.join("; "));
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("cloud-py accepts the PEP 440 normalized form in pyproject", () => {
+  // tag says 0.1.0-rc.1; the cloud pyproject stores the PEP 440 form 0.1.0rc1
+  const repo = makeRepo("0.1.0-rc.1", "0.1.0rc1");
+  try {
+    const r = checkReleaseTag("cloud-py-v0.1.0-rc.1", { root: repo.root });
+    assert.equal(r.ok, true, r.errors.join("; "));
+    assert.equal(r.unit, "cloud-py");
   } finally {
     repo.cleanup();
   }

--- a/scripts/publish-rc.sh
+++ b/scripts/publish-rc.sh
@@ -13,11 +13,15 @@
 #   telemetry-ts   -> @ratel-ai/telemetry on npm           (npm publish, built locally)
 #   telemetry-py   -> ratel-ai-telemetry on PyPI           (twine upload, built locally)
 #   telemetry-ts-otlp -> @ratel-ai/telemetry-otlp on npm      (npm publish, pnpm-packed locally)
+#   cloud-ts       -> @ratel-ai/cloud on npm              (npm publish, pnpm-packed locally)
+#   cloud-py       -> ratel-ai-cloud on PyPI              (twine upload, built locally)
 # Each unit's version is read from its own manifest via scripts/release-units.mjs
 # (the single source of truth) — units are NOT assumed to share a version.
 #
-# The telemetry units are pure-language (no cross-compiled native binaries), so this
-# helper BUILDS their npm/PyPI/crate artifacts locally — they need no --from-run/--from-dir.
+# The telemetry and cloud units are pure-language (no cross-compiled native binaries),
+# so this helper BUILDS their npm/PyPI/crate artifacts locally — they need no
+# --from-run/--from-dir. (cloud-ts's build compiles the @ratel-ai/sdk workspace
+# dependency, whose typegen needs a local Rust toolchain.)
 #
 # Usage:
 #   scripts/publish-rc.sh --unit sdk-ts --from-run <run-id> [--tag rc] [--dry-run]
@@ -28,7 +32,8 @@
 #
 # Options:
 #   --unit <id>        core | sdk-ts | sdk-py | telemetry-core | telemetry-ts |
-#                      telemetry-py | telemetry-ts-otlp. Repeatable. Default: all.
+#                      telemetry-py | telemetry-ts-otlp | cloud-ts | cloud-py.
+#                      Repeatable. Default: all.
 #   --from-run <id>    Download all artifacts from the given GH Actions run
 #                      (requires `gh auth login`); tarballs/wheels are found within.
 #   --from-dir <path>  Use a directory already holding the tarballs/wheels.
@@ -56,7 +61,7 @@ while [[ $# -gt 0 ]]; do
     --from-dir) FROM_DIR="$2"; shift 2 ;;
     --tag)      TAG="$2"; shift 2 ;;
     --dry-run)  DRY_RUN=1; shift ;;
-    -h|--help)  sed -n '2,36p' "$0"; exit 0 ;;
+    -h|--help)  sed -n '2,41p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -296,6 +301,55 @@ publish_telemetry_ts_otlp() {
   echo "==> telemetry-ts-otlp publish complete"; echo
 }
 
+# ---------- cloud-ts: @ratel-ai/cloud on npm, packed locally ----------
+# Pure TypeScript like telemetry-ts-otlp, with a workspace:^ dep on @ratel-ai/sdk.
+# `pnpm pack` rewrites that to a real version range in the tarball. Building the
+# @ratel-ai/sdk dependency runs its napi typegen, so a Rust toolchain is required.
+publish_cloud_ts() {
+  local version; version="$(resolve_version cloud-ts)"
+  echo "===== cloud-ts @ $version (npm) ====="
+  echo "----- @ratel-ai/cloud@$version (npm) -----"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    "https://registry.npmjs.org/@ratel-ai%2Fcloud/${version}" || echo 000)"
+  if [[ "$status" == "200" ]]; then
+    echo "    already published, skipping npm"; echo; return 0
+  fi
+  if [[ $DRY_RUN -eq 0 ]] && ! npm whoami >/dev/null 2>&1; then
+    echo "error: not logged in to npm. run 'npm login' first." >&2; exit 1
+  fi
+  # Build the loader + its @ratel-ai/sdk workspace dependency (topo order).
+  ( cd "$REPO_ROOT" && pnpm --filter "@ratel-ai/cloud..." run build )
+  local tgz
+  tgz="$( cd "$REPO_ROOT/src/sdk/cloud" && pnpm pack --pack-destination "$(mktemp -d)" | tail -1 )"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "    [dry-run] npm publish $tgz --access public --tag $TAG --provenance=false"
+  else
+    publish_one_npm "$tgz" || exit 1
+  fi
+  echo "==> cloud-ts publish complete"; echo
+}
+
+# ---------- cloud-py: ratel-ai-cloud on PyPI (pure-python wheel + sdist) ----------
+publish_cloud_py() {
+  local version; version="$(resolve_version cloud-py)"
+  echo "===== cloud-py @ $version (PyPI) ====="
+  echo "----- ratel-ai-cloud@$version (PyPI) -----"
+  if ! command -v twine >/dev/null 2>&1; then
+    echo "error: twine not found. 'pip install twine build' (auth via TWINE_* env or ~/.pypirc)." >&2; exit 1
+  fi
+  local dist; dist="$(mktemp -d)"
+  ( cd "$REPO_ROOT" && python -m build --outdir "$dist" src/sdk/cloud-py )
+  twine check "$dist"/*
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "    [dry-run] twine upload --skip-existing $dist/*"
+  else
+    # --skip-existing keeps re-runs idempotent.
+    twine upload --skip-existing "$dist"/*
+  fi
+  echo "==> cloud-py publish complete"; echo
+}
+
 # ---------- telemetry-core: ratel-ai-telemetry on crates.io ----------
 publish_telemetry_core() {
   local version; version="$(resolve_version telemetry-core)"
@@ -330,6 +384,8 @@ selected telemetry-core && publish_telemetry_core
 selected telemetry-ts   && publish_telemetry_ts
 selected telemetry-ts-otlp && publish_telemetry_ts_otlp
 selected telemetry-py   && publish_telemetry_py
+selected cloud-ts       && publish_cloud_ts
+selected cloud-py       && publish_cloud_py
 
 echo "==> done"
 echo

--- a/scripts/release-units.mjs
+++ b/scripts/release-units.mjs
@@ -107,6 +107,27 @@ export const UNITS = {
       includePaths: ["src/telemetry/python/**", "src/telemetry/CONVENTIONS.md", "src/telemetry/conformance/**"],
     },
   },
+  // The cloud catalog-source loaders (ADR-0003) are INDEPENDENT single-registry
+  // units, one per language — like the telemetry helpers. Each depends on its
+  // language SDK by version range (not lockstep), so a loader fix ships alone.
+  "cloud-ts": {
+    tagPrefix: "cloud-ts-v",
+    label: "@ratel-ai/cloud → npm",
+    versionManifest: { path: "src/sdk/cloud/package.json", kind: "json" },
+    manifests: [{ path: "src/sdk/cloud/package.json", kind: "json" }],
+    changelogs: ["src/sdk/cloud/CHANGELOG.md"],
+    srcPaths: ["src/sdk/cloud"],
+    changelog: { name: "@ratel-ai/cloud", includePaths: ["src/sdk/cloud/**"] },
+  },
+  "cloud-py": {
+    tagPrefix: "cloud-py-v",
+    label: "ratel-ai-cloud → PyPI",
+    versionManifest: { path: "src/sdk/cloud-py/pyproject.toml", kind: "toml", pep440: true },
+    manifests: [{ path: "src/sdk/cloud-py/pyproject.toml", kind: "toml", pep440: true }],
+    changelogs: ["src/sdk/cloud-py/CHANGELOG.md"],
+    srcPaths: ["src/sdk/cloud-py"],
+    changelog: { name: "ratel-ai-cloud", includePaths: ["src/sdk/cloud-py/**"] },
+  },
   // The OTLP exporter (init()), split from the npm vocabulary package so importing
   // the constants stays OTel-free (ADR-0007). npm-only; tracks only its own source
   // (a CONVENTIONS change is a vocabulary change, not an exporter change).

--- a/src/core/src/dense_cache.rs
+++ b/src/core/src/dense_cache.rs
@@ -27,8 +27,9 @@ pub(crate) trait Embeddable {
 /// Per-item dense vectors, a growing prefix of a registry's corpus.
 pub(crate) struct DenseCache {
     /// `vectors[i]` is the embedding for the registry's item `i`; any item beyond
-    /// `vectors.len()` is not yet embedded. Only appended to (never invalidated),
-    /// so an existing vector is never recomputed.
+    /// `vectors.len()` is not yet embedded. Appended to on `register` (an existing
+    /// vector is never recomputed) and dropped wholesale by [`Self::clear`] when a
+    /// registry mutation breaks the index alignment.
     vectors: Mutex<Vec<Vec<f32>>>,
     /// Test-only embedder override (`None` → the shared process bge-small, loaded
     /// lazily on first use). Lets tests inject a deterministic/failing embedder
@@ -75,6 +76,19 @@ impl DenseCache {
             return Err(EmbedderError::EmbeddingsNotBuilt);
         }
         Ok(())
+    }
+
+    /// Drop every cached vector (the embedder override survives). Registry
+    /// mutation (remove, in-place replace) breaks the index alignment the
+    /// prefix relies on — and can leave the cache longer than the corpus, where
+    /// [`Self::extend`] would early-return and stale vectors would rank against
+    /// the wrong items — so mutators must clear and let the next
+    /// `build_embeddings` re-embed the corpus.
+    pub(crate) fn clear(&self) {
+        self.vectors
+            .lock()
+            .expect("embeddings mutex poisoned")
+            .clear();
     }
 
     /// Embed the items not yet in the cache and append them — the incremental
@@ -214,6 +228,27 @@ mod tests {
         // Idempotent once caught up.
         cache.extend(&items, &NoopSink).unwrap();
         assert_eq!(stub.docs(), 3);
+    }
+
+    #[test]
+    fn clear_empties_the_cache_but_keeps_the_injected_embedder() {
+        let stub = Arc::new(CountingStub::new());
+        let cache = DenseCache::with_embedder(stub.clone());
+        let items = vec![doc("a", "read"), doc("b", "write")];
+        cache.extend(&items, &NoopSink).unwrap();
+        assert_eq!(stub.docs(), 2);
+
+        cache.clear();
+
+        assert!(matches!(
+            cache.require_built(items.len()),
+            Err(EmbedderError::EmbeddingsNotBuilt)
+        ));
+        // Re-extend re-embeds the whole corpus via the same injected embedder
+        // (no fallback to the process model).
+        cache.extend(&items, &NoopSink).unwrap();
+        assert_eq!(stub.docs(), 4);
+        assert!(cache.require_built(items.len()).is_ok());
     }
 
     #[test]

--- a/src/core/src/skill_registry.rs
+++ b/src/core/src/skill_registry.rs
@@ -74,10 +74,41 @@ impl SkillRegistry {
         self.skills.push(skill);
         // Append only — the new skill is embedded by the next `build_embeddings`
         // (a search never embeds); see [`crate::ToolRegistry::register`].
+        // Duplicate ids are possible and all get indexed (last wins at search
+        // time); id-stable callers (catalog sync) should use [`Self::upsert`].
         self.sink.record(TraceEvent::SkillChurn {
             kind: ChurnKind::Add,
             skill_id,
         });
+    }
+
+    /// Registers the skill, replacing any existing skill with the same id
+    /// (historical duplicates collapse). Emits `Remove` then `Add` churn on
+    /// replacement. Returns `true` when something was replaced.
+    pub fn upsert(&mut self, skill: Skill) -> bool {
+        let replaced = self.remove(&skill.id);
+        self.register(skill);
+        replaced
+    }
+
+    /// Removes every skill with the given id (tolerating historical duplicates
+    /// from [`Self::register`]). Returns `true` when anything was removed;
+    /// unknown ids are a no-op with no churn event.
+    pub fn remove(&mut self, skill_id: &str) -> bool {
+        let before = self.skills.len();
+        self.skills.retain(|s| s.id != skill_id);
+        let removed = self.skills.len() < before;
+        if removed {
+            // Removal breaks the dense cache's index alignment (and can leave
+            // it longer than the corpus); drop it and let the next
+            // `build_embeddings` re-embed. Covers `upsert`'s replace path too.
+            self.dense.clear();
+            self.sink.record(TraceEvent::SkillChurn {
+                kind: ChurnKind::Remove,
+                skill_id: skill_id.to_string(),
+            });
+        }
+        removed
     }
 
     pub fn search(&self, query: &str, top_k: usize) -> Vec<SkillHit> {
@@ -357,6 +388,197 @@ mod tests {
             &["backend", "api"],
         ));
         reg
+    }
+
+    #[test]
+    fn upsert_new_id_registers_and_emits_add() {
+        let sink = Arc::new(MemorySink::new("test-session"));
+        let mut reg = SkillRegistry::with_trace_sink(sink.clone());
+
+        let replaced = reg.upsert(skill(
+            "api-design",
+            "api-design",
+            "REST API design",
+            &["api"],
+        ));
+
+        assert!(!replaced);
+        let hits = reg.search("REST API design", 5);
+        assert_eq!(
+            hits.first().map(|h| h.skill_id.as_str()),
+            Some("api-design")
+        );
+        assert!(sink.drain().iter().any(|e| matches!(
+            e.event,
+            TraceEvent::SkillChurn {
+                kind: ChurnKind::Add,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn upsert_existing_id_replaces_and_reindexes_with_remove_then_add() {
+        let sink = Arc::new(MemorySink::new("test-session"));
+        let mut reg = SkillRegistry::with_trace_sink(sink.clone());
+        reg.register(skill(
+            "api-design",
+            "api-design",
+            "REST API design",
+            &["api"],
+        ));
+        sink.drain();
+
+        let replaced = reg.upsert(skill(
+            "api-design",
+            "api-design",
+            "GraphQL schema modeling",
+            &["graphql"],
+        ));
+
+        assert!(replaced);
+        let hits = reg.search("GraphQL schema", 5);
+        assert_eq!(
+            hits.first().map(|h| h.skill_id.as_str()),
+            Some("api-design")
+        );
+        assert!(reg.search("REST", 5).is_empty());
+        let churn: Vec<ChurnKind> = sink
+            .drain()
+            .into_iter()
+            .filter_map(|e| match e.event {
+                TraceEvent::SkillChurn { kind, .. } => Some(kind),
+                _ => None,
+            })
+            .collect();
+        assert!(matches!(
+            churn.as_slice(),
+            [ChurnKind::Remove, ChurnKind::Add]
+        ));
+    }
+
+    #[test]
+    fn remove_deletes_the_skill_and_emits_remove() {
+        let sink = Arc::new(MemorySink::new("test-session"));
+        let mut reg = SkillRegistry::with_trace_sink(sink.clone());
+        reg.register(skill(
+            "api-design",
+            "api-design",
+            "REST API design",
+            &["api"],
+        ));
+        sink.drain();
+
+        let removed = reg.remove("api-design");
+
+        assert!(removed);
+        assert!(reg.search("REST API design", 5).is_empty());
+        assert!(sink.drain().iter().any(|e| matches!(
+            e.event,
+            TraceEvent::SkillChurn {
+                kind: ChurnKind::Remove,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn remove_unknown_id_is_a_noop_without_events() {
+        let sink = Arc::new(MemorySink::new("test-session"));
+        let mut reg = SkillRegistry::with_trace_sink(sink.clone());
+
+        let removed = reg.remove("ghost");
+
+        assert!(!removed);
+        assert!(sink.drain().is_empty());
+    }
+
+    #[test]
+    fn remove_after_duplicate_registers_removes_all_occurrences() {
+        let mut reg = SkillRegistry::new();
+        reg.register(skill("dup", "dup", "REST API design", &["api"]));
+        reg.register(skill("dup", "dup", "REST API design", &["api"]));
+
+        assert!(reg.remove("dup"));
+
+        assert!(reg.search("REST API design", 5).is_empty());
+    }
+
+    #[test]
+    fn upsert_after_duplicate_registers_normalizes_to_one_skill() {
+        let mut reg = SkillRegistry::new();
+        reg.register(skill("dup", "dup", "REST API design", &["api"]));
+        reg.register(skill("dup", "dup", "REST API design", &["api"]));
+
+        assert!(reg.upsert(skill("dup", "dup", "GraphQL schema modeling", &["graphql"])));
+
+        assert!(reg.search("REST", 5).is_empty());
+        assert_eq!(reg.search("GraphQL schema", 5).len(), 1);
+    }
+
+    #[test]
+    fn upsert_replace_invalidates_dense_cache_and_rebuild_reflects_the_new_text() {
+        let mut reg = with_embedder(Arc::new(StubEmbedder));
+        // Neutral id: the stub embedder keys on the searchable text, which
+        // includes the name, so the id must not collide with its keywords.
+        reg.register(skill("writer", "writer", "REST API design", &["rest"]));
+        reg.register(skill("notes", "notes", "meeting notes", &["notes"]));
+        reg.build_embeddings().unwrap();
+
+        reg.upsert(skill("writer", "writer", "frontend slides", &["slides"]));
+
+        // The stale vectors are gone: semantic search demands a rebuild instead
+        // of silently ranking old embeddings against the mutated corpus.
+        assert!(matches!(
+            reg.search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic),
+            Err(EmbedderError::EmbeddingsNotBuilt)
+        ));
+
+        reg.build_embeddings().unwrap();
+        let hits = reg
+            .search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic)
+            .unwrap();
+        assert_eq!(hits.first().map(|h| h.skill_id.as_str()), Some("writer"));
+        assert!(hits[0].score > 0.9, "ranks with the replacement's vector");
+    }
+
+    #[test]
+    fn remove_invalidates_dense_cache_so_stale_vectors_never_outlive_the_corpus() {
+        let mut reg = with_embedder(Arc::new(StubEmbedder));
+        reg.register(skill(
+            "api-design",
+            "api-design",
+            "REST API design",
+            &["api"],
+        ));
+        reg.register(skill(
+            "frontend-slides",
+            "frontend-slides",
+            "frontend slides",
+            &["frontend"],
+        ));
+        reg.build_embeddings().unwrap();
+
+        reg.remove("api-design");
+
+        // Without invalidation the cache would be LONGER than the corpus:
+        // build_embeddings would early-return and the survivor would rank
+        // against the removed skill's vector.
+        assert!(matches!(
+            reg.search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic),
+            Err(EmbedderError::EmbeddingsNotBuilt)
+        ));
+
+        reg.build_embeddings().unwrap();
+        let hits = reg
+            .search_with_method("frontend slides", 5, Origin::Direct, SearchMethod::Semantic)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].skill_id, "frontend-slides");
+        assert!(
+            hits[0].score > 0.9,
+            "ranks with its own vector, not a stale one"
+        );
     }
 
     #[test]

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -7,8 +7,10 @@ Each SDK bundles the core (binding strategy varies per language; see the relevan
 ## Layout
 
 ```
-ts/        @ratel-ai/sdk — TypeScript SDK
-python/    ratel-ai — Python SDK
+ts/          @ratel-ai/sdk — TypeScript SDK
+python/      ratel-ai — Python SDK
+cloud/       @ratel-ai/cloud — TS catalog-source loader (protocol/v1 pull-sync)
+cloud-py/    ratel-ai-cloud — Python catalog-source loader (protocol/v1 pull-sync)
 ```
 
 Other languages land here when their milestones come up.
@@ -24,3 +26,13 @@ Binding strategy and tool-injection mode are locked in [ADR 0006](../../docs/adr
 The Python SDK. Bundles `ratel-ai-core` via a [PyO3](https://pyo3.rs) native binding under [`python/native/`](python/native/README.md), distributed as prebuilt `abi3` wheels. Full feature parity with the TS SDK. See [`python/README.md`](python/README.md) for usage.
 
 Binding strategy is locked in [ADR 0006](../../docs/adr/0006-native-ffi-bindings.md).
+
+## `cloud/` — `@ratel-ai/cloud`
+
+The TypeScript catalog-source loader: pull-syncs published skills from a networked source into a `SkillCatalog` over the frozen [protocol/v1](../../protocol/v1/README.md) contract. Pure TypeScript, no native binding. See [`cloud/README.md`](cloud/README.md).
+
+The source seam is locked in [ADR 0003](../../docs/adr/0003-catalog-source-interface.md).
+
+## `cloud-py/` — `ratel-ai-cloud`
+
+The Python catalog-source loader, mirror of `cloud/`. Pure Python (stdlib HTTP, no runtime dependencies beyond `ratel-ai`). See [`cloud-py/README.md`](cloud-py/README.md).

--- a/src/sdk/cloud-py/CHANGELOG.md
+++ b/src/sdk/cloud-py/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to `ratel-ai-cloud` (the Python cloud catalog-source loader) are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- The cloud catalog-source loader (ADR-0003) over the frozen protocol/v1 contract:
+  `create_skill_sync()` (offline-tolerant handle) and `sync_skills()` (one-shot),
+  `SkillSync` with the ownership rule (synced ids only; host skills reported in
+  `conflicts`, never touched), conditional-GET `fetch_catalog()` with a per-`(url, scope)`
+  ETag cache, and the typed error taxonomy (`ConfigError` / `AuthError` / `ApiError` /
+  `UnavailableError`) mapped from the frozen error body.
+- Canonicalization + ETag reference (`ratel_ai_cloud.canonical`) pinned to every
+  `protocol/v1/conformance/vectors.json` vector.
+- `ratel_ai_cloud.testing.MockSource`: an in-process HTTP catalog source (real ETag
+  algorithm, weak `If-None-Match`, scope overlay, Bearer auth, failure injection) for
+  loader tests.

--- a/src/sdk/cloud-py/LICENSE.md
+++ b/src/sdk/cloud-py/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Agentified
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/sdk/cloud-py/README.md
+++ b/src/sdk/cloud-py/README.md
@@ -1,0 +1,59 @@
+# `ratel-ai-cloud` (Python)
+
+Cloud catalog-source loader for the Python SDK: pull-syncs a project's published skills
+from a networked catalog source into a local `ratel_ai.SkillCatalog` over the frozen
+[protocol/v1 contract](../../../protocol/v1/README.md) (conditional GET + ETag, Bearer
+auth, opaque `?scope=`). Retrieval stays local — the source only answers a conditional
+GET ([ADR-0003](../../../docs/adr/0003-catalog-source-interface.md)). HTTP is stdlib
+`urllib`; the package is pure Python with no HTTP client dependency.
+
+## Usage
+
+```python
+from ratel_ai import SkillCatalog
+from ratel_ai_cloud import create_skill_sync
+
+catalog = SkillCatalog()
+# Reads RATEL_URL / RATEL_API_KEY unless url= / api_key= are passed explicitly.
+sync = create_skill_sync(catalog, interval_s=300)
+# ... catalog now serves synced skills to the capability tools ...
+sync.stop()
+```
+
+- `create_skill_sync(catalog, **options)` — offline-tolerant: hydrates now if the source
+  is reachable, keeps the last-pulled replica on transient failures, and (with
+  `interval_s`) keeps refreshing on a jittered timer. Staleness surfaces on the handle
+  as `last_synced_at` / `consecutive_failures`.
+- `sync_skills(catalog, **options)` — one-shot refresh that raises on any failure.
+- Explicit options beat the environment; no URL anywhere raises `ConfigError`
+  (`RATEL_URL` unset is the permanent embedded floor — no loader, app code unchanged).
+
+The loader owns only the skills it synced: host-registered skills are never touched, and
+an id collision is reported in `SyncResult.conflicts` instead of being overwritten.
+
+## Layout
+
+- `ratel_ai_cloud/canonical.py` — frozen v1 canonicalization, ETag, scope-overlay resolver.
+- `ratel_ai_cloud/errors.py` — typed errors mapped from the frozen error body.
+- `ratel_ai_cloud/fetch_catalog.py` — conditional GET of `/v1/catalog` via stdlib `urllib`.
+- `ratel_ai_cloud/skill_sync.py` — `SkillSync`: refresh/ownership/timer semantics.
+- `ratel_ai_cloud/testing/` — `MockSource`, an in-process conformant catalog source.
+- `tests/` — TDD suite, pinned to `protocol/v1/conformance/vectors.json`.
+
+## Package shape
+
+- Distribution name: `ratel-ai-cloud`; import name: `ratel_ai_cloud`
+- Pure Python (hatchling build, universal wheel); depends only on `ratel-ai`
+- MIT ([ADR-0009](../../../docs/adr/0009-licensing.md))
+
+## Build & test
+
+From this directory, reusing the Python SDK's venv (which has `ratel_ai` installed via
+`maturin develop` — see [`../python/README.md`](../python/README.md) for its setup):
+
+```bash
+uv pip install --python ../python/.venv -e .
+../python/.venv/bin/ruff check .
+../python/.venv/bin/mypy ratel_ai_cloud
+../python/.venv/bin/pytest
+```

--- a/src/sdk/cloud-py/pyproject.toml
+++ b/src/sdk/cloud-py/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ratel-ai-cloud"
+version = "0.1.0rc1"
+description = "Ratel cloud catalog-source loader — pull-syncs published skills into a local SkillCatalog over the frozen protocol/v1 contract."
+readme = "README.md"
+license = { file = "LICENSE.md" }
+authors = [{ name = "Agentified" }]
+requires-python = ">=3.9"
+keywords = [
+    "skills",
+    "catalog",
+    "pull-sync",
+    "context-engineering",
+    "ai-agents",
+    "ratel",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+# HTTP is stdlib urllib — the loader adds no HTTP client dependency. ratel-ai
+# supplies the SkillCatalog it hydrates and the source-config seam (ADR-0003).
+dependencies = ["ratel-ai>=0.3.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "ruff>=0.6", "mypy>=1.11"]
+
+[project.urls]
+Homepage = "https://github.com/ratel-ai/ratel"
+Repository = "https://github.com/ratel-ai/ratel"
+Issues = "https://github.com/ratel-ai/ratel/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ratel_ai_cloud"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "W"]
+
+# Runtime floor is 3.9 (via `from __future__ import annotations`); mypy's minimum
+# supported target is 3.10, so we type-check against that (matches the Python SDK).
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["ratel_ai._native"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/sdk/cloud-py/ratel_ai_cloud/__init__.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/__init__.py
@@ -1,0 +1,97 @@
+"""Ratel cloud catalog-source loader (protocol/v1 pull-sync).
+
+Pull-syncs a project's published skills into a local `ratel_ai.SkillCatalog`
+over the frozen protocol/v1 contract; retrieval stays local (ADR-0003).
+`create_skill_sync` is the offline-tolerant handle; `sync_skills` the one-shot
+that raises. Configuration follows the source seam: explicit options beat the
+`RATEL_URL` / `RATEL_API_KEY` environment; no url anywhere is a `ConfigError`
+(unset `RATEL_URL` is the embedded floor — hosts simply don't attach a loader).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ratel_ai import SkillCatalog, SourceConfig, SourceOptions, resolve_source_config
+
+from .errors import ApiError, AuthError, ConfigError, UnavailableError
+from .fetch_catalog import (
+    CatalogChanged,
+    CatalogResponse,
+    CatalogUnchanged,
+    FetchCatalogResult,
+    fetch_catalog,
+)
+from .skill_sync import SkillSync, SyncResult, skills_equal
+
+__all__ = [
+    "ApiError",
+    "AuthError",
+    "CatalogChanged",
+    "CatalogResponse",
+    "CatalogUnchanged",
+    "ConfigError",
+    "FetchCatalogResult",
+    "SkillSync",
+    "SyncResult",
+    "UnavailableError",
+    "create_skill_sync",
+    "fetch_catalog",
+    "skills_equal",
+    "sync_skills",
+]
+
+
+def _resolve(
+    url: str | None,
+    api_key: str | None,
+    scope: str | None,
+    env: Mapping[str, str] | None,
+) -> SourceConfig:
+    config = resolve_source_config(SourceOptions(url=url, api_key=api_key, scope=scope), env)
+    if config is None:
+        raise ConfigError(
+            "no catalog source configured: pass url= or set RATEL_URL (ADR-0003)"
+        )
+    return config
+
+
+def create_skill_sync(
+    catalog: SkillCatalog,
+    *,
+    url: str | None = None,
+    api_key: str | None = None,
+    scope: str | None = None,
+    interval_s: float | None = None,
+    env: Mapping[str, str] | None = None,
+) -> SkillSync:
+    """Attach a source loader to `catalog` and return the sync handle.
+
+    Offline-tolerant: the initial refresh failure is swallowed (staleness
+    surfaces as `last_synced_at` / `consecutive_failures`); with `interval_s`
+    the handle keeps refreshing on a jittered timer — unless the source
+    rejected the key, which stops the chain before it starts.
+    """
+    sync = SkillSync(catalog, _resolve(url, api_key, scope, env))
+    auth_failed = False
+    try:
+        sync.refresh()
+    except AuthError:
+        auth_failed = True
+    except (ApiError, UnavailableError):
+        pass
+    if interval_s is not None and not auth_failed:
+        sync.start(interval_s)
+    return sync
+
+
+def sync_skills(
+    catalog: SkillCatalog,
+    *,
+    url: str | None = None,
+    api_key: str | None = None,
+    scope: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> SyncResult:
+    """One-shot pull-sync into `catalog`; raises on any failure."""
+    return SkillSync(catalog, _resolve(url, api_key, scope, env)).refresh()

--- a/src/sdk/cloud-py/ratel_ai_cloud/canonical.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/canonical.py
@@ -1,0 +1,84 @@
+"""Frozen v1 canonicalization — the Python mirror of the reference
+implementation in `protocol/v1/conformance/verify.mjs`.
+
+The ETag content projection is frozen at v1 (see `protocol/v1/README.md`):
+exactly the seven wire fields in a fixed key order, `metadata` keys sorted by
+UTF-8 byte order, arrays in authored order, raw UTF-8, compact JSON, set sorted
+by `id`. Runtime uses this for nothing but tests and the mock source — a loader
+trusts the server's ETag; recomputation is a test-only integrity check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
+
+__all__ = ["SKILL_FIELDS", "Etag", "canonical_set", "canonical_skill", "etag_of", "resolve"]
+
+# The frozen v1 content projection: exactly these fields, in this order.
+SKILL_FIELDS = ("id", "name", "description", "tags", "tools", "metadata", "body")
+
+
+class Etag(NamedTuple):
+    hex: str
+    etag: str  # the strong entity-tag: `"<hex>"`
+
+
+def _json(value: Any) -> str:
+    # Compact separators + ensure_ascii=False match JSON.stringify: minimal
+    # escaping, raw UTF-8, no insignificant whitespace.
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _utf8(key: str) -> bytes:
+    return key.encode("utf-8")
+
+
+def canonical_skill(skill: Mapping[str, Any]) -> str:
+    """Canonical JSON for one skill, projected to exactly the seven wire fields."""
+    metadata: Mapping[str, Any] = skill.get("metadata") or {}
+    meta_keys = sorted(metadata, key=_utf8)
+    meta = "{" + ",".join(_json(k) + ":" + _json(metadata[k]) for k in meta_keys) + "}"
+    return (
+        "{"
+        + '"id":' + _json(skill["id"]) + ","
+        + '"name":' + _json(skill["name"]) + ","
+        + '"description":' + _json(skill["description"]) + ","
+        + '"tags":' + _json(skill["tags"]) + ","
+        + '"tools":' + _json(skill["tools"]) + ","
+        + '"metadata":' + meta + ","
+        + '"body":' + _json(skill["body"])
+        + "}"
+    )
+
+
+def _sort_by_id(skills: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    return sorted(skills, key=lambda s: _utf8(s["id"]))
+
+
+def canonical_set(skills: Sequence[Mapping[str, Any]]) -> str:
+    """Canonical bytes for a resolved set: sorted by id, compact JSON array."""
+    return "[" + ",".join(canonical_skill(s) for s in _sort_by_id(skills)) + "]"
+
+
+def etag_of(skills: Sequence[Mapping[str, Any]]) -> Etag:
+    hex_digest = hashlib.sha256(canonical_set(skills).encode("utf-8")).hexdigest()
+    return Etag(hex=hex_digest, etag=f'"{hex_digest}"')
+
+
+def resolve(catalog: Mapping[str, Any], scope: str | None) -> list[Mapping[str, Any]]:
+    """Resolve the published set for a scope: absent scope => the global layer;
+    a subject => its layer overlaid on global, subject winning on `name`
+    collision; an unknown subject => the global layer (empty overlay)."""
+    global_layer: Sequence[Mapping[str, Any]] = catalog.get("global") or []
+    if scope is None:
+        return _sort_by_id(global_layer)
+    subject_layer: Sequence[Mapping[str, Any]] = (catalog.get("subjects") or {}).get(scope) or []
+    by_name: dict[str, Mapping[str, Any]] = {}
+    for skill in global_layer:
+        by_name[skill["name"]] = skill
+    for skill in subject_layer:
+        by_name[skill["name"]] = skill
+    return _sort_by_id(list(by_name.values()))

--- a/src/sdk/cloud-py/ratel_ai_cloud/errors.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/errors.py
@@ -1,0 +1,92 @@
+"""Typed error taxonomy for the loader, mapped from the frozen v1 error body
+`{error: {code, message, details?}}` (`protocol/v1/schema/error.schema.json`).
+A malformed body is tolerated — the HTTP status alone picks the type and a
+per-status fallback code.
+"""
+
+from __future__ import annotations
+
+import json
+
+__all__ = [
+    "ApiError",
+    "AuthError",
+    "ConfigError",
+    "UnavailableError",
+    "error_from_response",
+]
+
+
+class ConfigError(Exception):
+    """No source is configured / the configuration is unusable. Fails fast,
+    never retried."""
+
+
+class ApiError(Exception):
+    """Any non-2xx the source answered with. `status` is the HTTP status
+    (`None` only for network-level failures, see `UnavailableError`); `code`
+    is the frozen error-body code, or a per-status fallback."""
+
+    def __init__(self, message: str, status: int | None, code: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class AuthError(ApiError):
+    """401 — missing, malformed, unknown, or revoked key. Terminal for a
+    sync chain."""
+
+    def __init__(self, message: str, status: int = 401, code: str = "unauthorized") -> None:
+        super().__init__(message, status, code)
+
+
+class UnavailableError(ApiError):
+    """503 or a network-level failure (`status=None`) — the source is
+    unreachable; the last-pulled replica stays live."""
+
+    def __init__(
+        self, message: str, status: int | None = 503, code: str = "unavailable"
+    ) -> None:
+        super().__init__(message, status, code)
+
+
+_FALLBACK_CODES = {
+    400: "invalid_request",
+    401: "unauthorized",
+    404: "not_found",
+    503: "unavailable",
+}
+
+
+def _parse_error_body(body: bytes) -> tuple[str | None, str | None]:
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None, None
+    if not isinstance(parsed, dict):
+        return None, None
+    error = parsed.get("error")
+    if not isinstance(error, dict):
+        return None, None
+    code = error.get("code")
+    message = error.get("message")
+    return (
+        code if isinstance(code, str) else None,
+        message if isinstance(message, str) else None,
+    )
+
+
+def error_from_response(status: int, body: bytes) -> ApiError:
+    """Map a non-2xx `/v1` response to a typed error, tolerating malformed
+    bodies (the HTTP status wins)."""
+    body_code, body_message = _parse_error_body(body)
+    code = body_code or _FALLBACK_CODES.get(status, "unknown")
+    message = f"catalog source responded {status}"
+    if body_message:
+        message = f"{message}: {body_message}"
+    if status == 401:
+        return AuthError(message, status=status, code=code)
+    if status == 503:
+        return UnavailableError(message, status=status, code=code)
+    return ApiError(message, status, code)

--- a/src/sdk/cloud-py/ratel_ai_cloud/fetch_catalog.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/fetch_catalog.py
@@ -1,0 +1,106 @@
+"""One conditional GET of a source's `/v1/catalog` — the single place the
+loader touches the network (stdlib `urllib`, no HTTP client dependency).
+Everything above it consumes the changed/unchanged result objects.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Union
+from urllib.parse import urlencode
+
+from ratel_ai import SourceConfig
+
+from .errors import ApiError, UnavailableError, error_from_response
+
+__all__ = [
+    "CatalogChanged",
+    "CatalogResponse",
+    "CatalogUnchanged",
+    "FetchCatalogResult",
+    "fetch_catalog",
+]
+
+_TIMEOUT_S = 30.0
+
+
+@dataclass(frozen=True)
+class CatalogResponse:
+    """The 200 body of `GET /v1/catalog` (`catalog-response.schema.json`).
+    `skills` stay in wire shape; callers project them."""
+
+    catalog_version: str
+    skills: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class CatalogChanged:
+    etag: str
+    catalog: CatalogResponse
+    changed: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True)
+class CatalogUnchanged:
+    changed: bool = field(default=False, init=False)
+
+
+FetchCatalogResult = Union[CatalogChanged, CatalogUnchanged]
+
+
+def fetch_catalog(config: SourceConfig, etag: str | None = None) -> FetchCatalogResult:
+    """Conditional GET of `{config.url}/v1/catalog` (+ `?scope=`). Sends the
+    Bearer key on every request and `If-None-Match` when `etag` is known;
+    raises the typed errors from `.errors` on any failure."""
+    url = f"{config.url.rstrip('/')}/v1/catalog"
+    if config.scope is not None:
+        url += "?" + urlencode({"scope": config.scope})
+
+    request = urllib.request.Request(url)
+    if config.api_key is not None:
+        request.add_header("Authorization", f"Bearer {config.api_key}")
+    if etag is not None:
+        request.add_header("If-None-Match", etag)
+
+    try:
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
+            status: int = response.status
+            header_etag: str | None = response.headers.get("ETag")
+            body = response.read()
+    except urllib.error.HTTPError as err:
+        if err.code == 304:
+            return CatalogUnchanged()
+        try:
+            error_body = err.read()
+        except OSError:
+            error_body = b""
+        raise error_from_response(err.code, error_body) from None
+    except (urllib.error.URLError, OSError) as err:
+        raise UnavailableError(
+            f"catalog source unreachable: {config.url}: {err}", status=None
+        ) from err
+
+    if status == 304:
+        return CatalogUnchanged()
+
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        raise ApiError(
+            "catalog source returned a non-JSON 200 body", status, "invalid_body"
+        ) from None
+    catalog_version = parsed.get("catalogVersion") if isinstance(parsed, dict) else None
+    skills = parsed.get("skills") if isinstance(parsed, dict) else None
+    if not isinstance(catalog_version, str) or not isinstance(skills, list):
+        raise ApiError(
+            "catalog source returned an invalid catalog body (catalogVersion/skills)",
+            status,
+            "invalid_body",
+        )
+    return CatalogChanged(
+        etag=header_etag or f'"{catalog_version}"',
+        catalog=CatalogResponse(catalog_version=catalog_version, skills=skills),
+    )

--- a/src/sdk/cloud-py/ratel_ai_cloud/skill_sync.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/skill_sync.py
@@ -1,0 +1,183 @@
+"""`SkillSync` — pull-syncs a source's published skills into a host-owned
+`SkillCatalog` under the ownership rule: the loader mutates only the ids it
+synced itself; a host-registered skill with a colliding id is reported in
+`SyncResult.conflicts` and never touched. The replica is in-memory only;
+staleness surfaces as `last_synced_at` / `consecutive_failures` (ADR-0003).
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from ratel_ai import Skill, SkillCatalog, SourceConfig
+
+from .canonical import SKILL_FIELDS
+from .errors import ApiError, AuthError
+from .fetch_catalog import CatalogChanged, FetchCatalogResult, fetch_catalog
+
+__all__ = ["SkillSync", "SyncResult", "skills_equal"]
+
+FetchImpl = Callable[[SourceConfig, Optional[str]], FetchCatalogResult]
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    added: int
+    updated: int
+    removed: int
+    # Ids present in the catalog but not owned by this sync — host skills the
+    # ownership rule refused to overwrite.
+    conflicts: list[str]
+    # True when the source answered 304 for the cached etag.
+    unchanged: bool
+
+
+def skills_equal(a: Skill, b: Skill) -> bool:
+    """Field-wise equality over exactly the 7 wire fields — the same set the
+    frozen ETag projection hashes, so an identical resync emits zero churn."""
+    return all(getattr(a, f) == getattr(b, f) for f in SKILL_FIELDS)
+
+
+def _to_skill(wire: dict[str, Any]) -> Skill:
+    """Project a wire skill to the 7 fields (unknown fields are ignored)."""
+    return Skill(
+        id=wire["id"],
+        name=wire["name"],
+        description=wire["description"],
+        tags=list(wire["tags"]),
+        tools=list(wire["tools"]),
+        metadata={k: list(v) for k, v in wire["metadata"].items()},
+        body=wire["body"],
+    )
+
+
+def _jittered_interval(interval_s: float) -> float:
+    """The next tick's delay: the interval with ±10% jitter, so a fleet of
+    loaders never revalidates in lockstep."""
+    return interval_s * (0.9 + 0.2 * random.random())
+
+
+@dataclass
+class SkillSync:
+    """A sync handle for one `(source url, scope)`. `refresh()` is one
+    conditional pull + diff apply; `start()` keeps refreshing on a jittered
+    timer chain until `stop()` or a permanent auth failure."""
+
+    catalog: SkillCatalog
+    config: SourceConfig
+    fetch_impl: FetchImpl = field(default=fetch_catalog)
+
+    def __post_init__(self) -> None:
+        self._refresh_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._etag: str | None = None
+        self._synced_ids: set[str] = set()
+        self._last_synced_at: datetime | None = None
+        self._consecutive_failures = 0
+        self._interval_s: float | None = None
+        self._timer: threading.Timer | None = None
+        self._stopped = False
+        self._auth_failed = False
+
+    @property
+    def last_synced_at(self) -> datetime | None:
+        return self._last_synced_at
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._consecutive_failures
+
+    @property
+    def owned_count(self) -> int:
+        return len(self._synced_ids)
+
+    def refresh(self) -> SyncResult:
+        """One conditional pull + diff apply, serialized via a lock. Raises the
+        typed fetch errors; a failure keeps the replica and bumps
+        `consecutive_failures`."""
+        with self._refresh_lock:
+            try:
+                result = self.fetch_impl(self.config, self._etag)
+            except Exception:
+                self._consecutive_failures += 1
+                raise
+            sync_result = (
+                self._apply(result)
+                if isinstance(result, CatalogChanged)
+                else SyncResult(added=0, updated=0, removed=0, conflicts=[], unchanged=True)
+            )
+            self._last_synced_at = datetime.now(timezone.utc)
+            self._consecutive_failures = 0
+            return sync_result
+
+    def _apply(self, result: CatalogChanged) -> SyncResult:
+        added = updated = removed = 0
+        conflicts: list[str] = []
+        wire_ids: set[str] = set()
+        for wire in result.catalog.skills:
+            skill = _to_skill(wire)
+            wire_ids.add(skill.id)
+            if skill.id in self._synced_ids:
+                existing = self.catalog.get(skill.id)
+                if existing is None or not skills_equal(existing, skill):
+                    self.catalog.upsert(skill)
+                    updated += 1
+            elif self.catalog.has(skill.id):
+                conflicts.append(skill.id)
+            else:
+                self.catalog.register(skill)
+                self._synced_ids.add(skill.id)
+                added += 1
+        for gone in sorted(self._synced_ids - wire_ids):
+            self.catalog.remove(gone)
+            self._synced_ids.discard(gone)
+            removed += 1
+        self._etag = result.etag
+        return SyncResult(
+            added=added, updated=updated, removed=removed, conflicts=conflicts, unchanged=False
+        )
+
+    def start(self, interval_s: float) -> None:
+        """Keep refreshing every `interval_s` seconds (±10% jitter) on a daemon
+        timer chain. Transient errors keep the chain; an auth failure stops it
+        permanently."""
+        with self._state_lock:
+            if self._auth_failed:
+                return
+            self._stopped = False
+            self._interval_s = interval_s
+            self._schedule_locked()
+
+    def stop(self) -> None:
+        """Cancel the timer chain. Idempotent and safe to race with a tick."""
+        with self._state_lock:
+            self._stopped = True
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def _schedule_locked(self) -> None:
+        if self._stopped or self._auth_failed or self._interval_s is None:
+            return
+        timer = threading.Timer(_jittered_interval(self._interval_s), self._tick)
+        timer.daemon = True
+        self._timer = timer
+        timer.start()
+
+    def _tick(self) -> None:
+        try:
+            self.refresh()
+        except AuthError:
+            with self._state_lock:
+                self._auth_failed = True
+                self._timer = None
+            return
+        except ApiError:
+            pass  # transient — the replica stays live, the chain continues
+        with self._state_lock:
+            self._timer = None
+            self._schedule_locked()

--- a/src/sdk/cloud-py/ratel_ai_cloud/testing/__init__.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Test doubles for loader tests — see `mock_source`."""

--- a/src/sdk/cloud-py/ratel_ai_cloud/testing/mock_source.py
+++ b/src/sdk/cloud-py/ratel_ai_cloud/testing/mock_source.py
@@ -1,0 +1,211 @@
+"""An in-process catalog source for loader tests: a real HTTP server that
+implements the frozen protocol/v1 behavior — Bearer auth with the frozen 401
+body, scope overlay, the real ETag algorithm (quoted strong header, bare-hex
+`catalogVersion`), weak `If-None-Match` => 304, unauthenticated `/healthz` —
+plus request recording and failure injection. Test-only; never shipped into a
+runtime code path.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from ..canonical import SKILL_FIELDS, etag_of, resolve
+
+__all__ = ["MockSource", "RecordedRequest"]
+
+
+@dataclass
+class RecordedRequest:
+    method: str
+    path: str
+    scope: str | None
+    headers: dict[str, str]
+
+
+@dataclass
+class _InjectedFailure:
+    status: int
+    code: str
+    times: int
+
+
+def _opaque(tag: str) -> str:
+    """Strip a `W/` weak prefix and surrounding quotes to the opaque value."""
+    t = tag.strip()
+    if t.startswith("W/"):
+        t = t[2:].strip()
+    if len(t) >= 2 and t.startswith('"') and t.endswith('"'):
+        t = t[1:-1]
+    return t
+
+
+def _if_none_match_matches(header_value: str | None, current_etag: str) -> bool:
+    """Weak comparison per RFC 7232 §3.2: tolerate `W/`, quotes, comma-lists,
+    and `*` (matches any current representation)."""
+    if header_value is None:
+        return False
+    value = header_value.strip()
+    if value == "*":
+        return True
+    current = _opaque(current_etag)
+    return any(
+        _opaque(token) == current and _opaque(token) != ""
+        for token in value.split(",")
+    )
+
+
+def _project(skill: Mapping[str, Any]) -> dict[str, Any]:
+    """The frozen wire projection: exactly the seven fields, fixed key order —
+    the structural guarantee that a secret-bearing field never leaves the source."""
+    return {key: skill[key] for key in SKILL_FIELDS}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: MockSourceServer
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server naming
+        source = self.server.source
+        split = urlsplit(self.path)
+        scope_values = parse_qs(split.query).get("scope")
+        scope = scope_values[0] if scope_values else None
+        headers = {k.lower(): v for k, v in self.headers.items()}
+        with source._lock:
+            source.requests.append(
+                RecordedRequest(method="GET", path=split.path, scope=scope, headers=headers)
+            )
+
+        if split.path == "/healthz":
+            self._respond(200, b"")
+            return
+
+        failure = source._take_failure()
+        if failure is not None:
+            self._error(failure.status, failure.code, "injected failure")
+            return
+
+        if headers.get("authorization") != f"Bearer {source.api_key}":
+            self._error(401, "unauthorized", "missing or unknown key")
+            return
+
+        if split.path != "/v1/catalog":
+            self._error(404, "not_found", f"no such resource: {split.path}")
+            return
+
+        with source._lock:
+            layers = source._layers
+        resolved = [_project(s) for s in resolve(layers, scope)]
+        etag = etag_of(resolved)
+        if _if_none_match_matches(headers.get("if-none-match"), etag.etag):
+            self.send_response(304)
+            self.send_header("ETag", etag.etag)
+            self.end_headers()
+            return
+        body = json.dumps(
+            {"catalogVersion": etag.hex, "skills": resolved}, ensure_ascii=False
+        ).encode("utf-8")
+        headers_out = {
+            "ETag": etag.etag,
+            "Cache-Control": "no-cache",
+            "Content-Type": "application/json",
+        }
+        self._respond(200, body, extra=headers_out)
+
+    def _error(self, status: int, code: str, message: str) -> None:
+        body = json.dumps({"error": {"code": code, "message": message}}).encode("utf-8")
+        self._respond(status, body, extra={"Content-Type": "application/json"})
+
+    def _respond(self, status: int, body: bytes, extra: dict[str, str] | None = None) -> None:
+        self.send_response(status)
+        for key, value in (extra or {}).items():
+            self.send_header(key, value)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass  # keep test output clean
+
+
+class MockSourceServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, source: MockSource) -> None:
+        super().__init__(("127.0.0.1", 0), _Handler)
+        self.source = source
+
+
+@dataclass
+class MockSource:
+    """A conformant in-process catalog source on an OS-assigned port."""
+
+    api_key: str = "test-key"
+    requests: list[RecordedRequest] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self._lock = threading.Lock()
+        self._layers: dict[str, Any] = {"global": [], "subjects": {}}
+        self._failure: _InjectedFailure | None = None
+        self._server: MockSourceServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        if self._server is None:
+            raise RuntimeError("MockSource is not started")
+        return f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    def start(self) -> MockSource:
+        self._server = MockSourceServer(self)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    def __enter__(self) -> MockSource:
+        return self.start()
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    def set_skills(self, skills: list[dict[str, Any]]) -> None:
+        """Replace the global layer (subject layers untouched)."""
+        with self._lock:
+            self._layers = {**self._layers, "global": list(skills)}
+
+    def set_layers(self, layers: dict[str, Any]) -> None:
+        """Replace the full catalog: `{"global": [...], "subjects": {...}}`."""
+        with self._lock:
+            self._layers = {
+                "global": list(layers.get("global") or []),
+                "subjects": dict(layers.get("subjects") or {}),
+            }
+
+    def inject_failure(self, status: int, code: str = "unavailable", times: int = 1) -> None:
+        """Fail the next `times` catalog requests with the frozen error body."""
+        with self._lock:
+            self._failure = _InjectedFailure(status=status, code=code, times=times)
+
+    def _take_failure(self) -> _InjectedFailure | None:
+        with self._lock:
+            failure = self._failure
+            if failure is None:
+                return None
+            failure.times -= 1
+            if failure.times <= 0:
+                self._failure = None
+            return failure

--- a/src/sdk/cloud-py/tests/conftest.py
+++ b/src/sdk/cloud-py/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures: the frozen protocol/v1 conformance vectors, loaded from the
+repo checkout (this package's tests are the loader-side conformance run)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+VECTORS_PATH = REPO_ROOT / "protocol" / "v1" / "conformance" / "vectors.json"
+
+
+@pytest.fixture(scope="session")
+def vectors() -> dict[str, Any]:
+    return json.loads(VECTORS_PATH.read_text(encoding="utf-8"))  # type: ignore[no-any-return]

--- a/src/sdk/cloud-py/tests/test_canonical.py
+++ b/src/sdk/cloud-py/tests/test_canonical.py
@@ -1,0 +1,126 @@
+"""Loader-side conformance: `ratel_ai_cloud.canonical` must reproduce every
+committed vector in `protocol/v1/conformance/vectors.json` byte-for-byte."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from ratel_ai_cloud.canonical import (
+    SKILL_FIELDS,
+    canonical_set,
+    canonical_skill,
+    etag_of,
+    resolve,
+)
+
+
+def _etag_by_name(vectors: dict[str, Any], name: str) -> str:
+    vector = next(v for v in vectors["etag"] if v["name"] == name)
+    catalog = vectors["catalogs"][vector["catalog"]]
+    return etag_of(resolve(catalog, vector.get("scope"))).etag
+
+
+def test_every_etag_vector(vectors: dict[str, Any]) -> None:
+    for vector in vectors["etag"]:
+        catalog = vectors["catalogs"][vector["catalog"]]
+        resolved = resolve(catalog, vector.get("scope"))
+        assert [s["id"] for s in resolved] == vector["expect"]["resolvedIds"], vector["name"]
+        assert etag_of(resolved).etag == vector["expect"]["etag"], vector["name"]
+
+
+def test_every_equal_etags_group(vectors: dict[str, Any]) -> None:
+    for group in vectors["equalEtags"]:
+        tags = {_etag_by_name(vectors, name) for name in group}
+        assert len(tags) == 1, group
+
+
+def test_every_distinct_etags_group(vectors: dict[str, Any]) -> None:
+    for group in vectors["distinctEtags"]:
+        tags = {_etag_by_name(vectors, name) for name in group}
+        assert len(tags) == len(group), group
+
+
+def test_etag_is_lowercase_hex_sha256_of_canonical_set(vectors: dict[str, Any]) -> None:
+    skills = vectors["catalogs"]["basic"]["global"]
+    expected_hex = hashlib.sha256(canonical_set(skills).encode("utf-8")).hexdigest()
+    result = etag_of(skills)
+    assert result.hex == expected_hex
+    assert result.etag == f'"{expected_hex}"'
+
+
+def test_empty_set_canonicalizes_to_bare_brackets() -> None:
+    assert canonical_set([]) == "[]"
+    assert etag_of([]).hex == hashlib.sha256(b"[]").hexdigest()
+
+
+def test_canonical_skill_fixed_key_order_and_projection() -> None:
+    skill = {
+        "metadata": {"cat": ["a"]},
+        "body": "# A\n",
+        "tools": ["t1"],
+        "id": "a",
+        "tags": ["x"],
+        "description": "First.",
+        "name": "alpha",
+        "status": "published",
+        "updatedAt": "2026-01-01T00:00:00Z",
+    }
+    assert canonical_skill(skill) == (
+        '{"id":"a","name":"alpha","description":"First.",'
+        '"tags":["x"],"tools":["t1"],"metadata":{"cat":["a"]},"body":"# A\\n"}'
+    )
+
+
+def test_metadata_keys_sorted_by_utf8_bytes_arrays_authored_order() -> None:
+    skill = {
+        "id": "u",
+        "name": "n",
+        "description": "d",
+        "tags": ["食", "x"],
+        "tools": [],
+        "metadata": {"región": ["MX"], "área": ["café"]},
+        "body": "b",
+    }
+    # "región" (r=0x72) sorts before "área" (0xc3 first byte) bytewise;
+    # non-ASCII stays raw UTF-8, never \u-escaped; tags keep authored order.
+    assert canonical_skill(skill) == (
+        '{"id":"u","name":"n","description":"d","tags":["食","x"],"tools":[],'
+        '"metadata":{"región":["MX"],"área":["café"]},"body":"b"}'
+    )
+
+
+def test_scope_overlay_subject_wins_on_name_collision(vectors: dict[str, Any]) -> None:
+    catalog = vectors["catalogs"]["scoped"]
+    resolved = resolve(catalog, "alice")
+    by_id = {s["id"]: s for s in resolved}
+    # `g-search` collides on name `search-web`: Alice's copy wins.
+    assert by_id["g-search"]["body"] == "alice search\n"
+    assert by_id["g-email"]["body"] == "global email\n"
+
+
+def test_scope_overlay_unknown_or_absent_subject_is_global_only(vectors: dict[str, Any]) -> None:
+    catalog = vectors["catalogs"]["scoped"]
+    assert resolve(catalog, "carol") == resolve(catalog, None)
+    assert [s["id"] for s in resolve(catalog, None)] == ["g-email", "g-search"]
+
+
+def test_wire_secrets_rule_structural(vectors: dict[str, Any]) -> None:
+    wire = vectors["wire"]
+    assert list(SKILL_FIELDS) == wire["skillFields"]
+    for field in SKILL_FIELDS:
+        for forbidden in wire["forbiddenFieldSubstrings"]:
+            assert forbidden not in field.lower()
+    # The projection drops any field a secret could ride in on.
+    leaky = {
+        "id": "s",
+        "name": "n",
+        "description": "d",
+        "tags": [],
+        "tools": [],
+        "metadata": {},
+        "body": "b",
+        "apiKey": "sk-LEAK",
+        "authorization": "Bearer LEAK",
+    }
+    assert "LEAK" not in canonical_skill(leaky)

--- a/src/sdk/cloud-py/tests/test_errors.py
+++ b/src/sdk/cloud-py/tests/test_errors.py
@@ -1,0 +1,71 @@
+"""Typed error taxonomy mapped from the frozen `{error:{code,message,details?}}` body."""
+
+from __future__ import annotations
+
+import json
+
+from ratel_ai_cloud.errors import (
+    ApiError,
+    AuthError,
+    ConfigError,
+    UnavailableError,
+    error_from_response,
+)
+
+
+def _body(code: str, message: str) -> bytes:
+    return json.dumps({"error": {"code": code, "message": message}}).encode("utf-8")
+
+
+def test_401_maps_to_auth_error() -> None:
+    err = error_from_response(401, _body("unauthorized", "unknown key"))
+    assert isinstance(err, AuthError)
+    assert isinstance(err, ApiError)
+    assert err.status == 401
+    assert err.code == "unauthorized"
+    assert "unknown key" in str(err)
+
+
+def test_503_maps_to_unavailable_error() -> None:
+    err = error_from_response(503, _body("unavailable", "key store unreachable"))
+    assert isinstance(err, UnavailableError)
+    assert isinstance(err, ApiError)
+    assert err.status == 503
+    assert err.code == "unavailable"
+
+
+def test_other_statuses_map_to_api_error() -> None:
+    err = error_from_response(404, _body("not_found", "no such catalog"))
+    assert type(err) is ApiError
+    assert err.status == 404
+    assert err.code == "not_found"
+
+    err = error_from_response(400, _body("invalid_request", "bad scope"))
+    assert err.status == 400
+    assert err.code == "invalid_request"
+
+
+def test_malformed_bodies_are_tolerated() -> None:
+    for status, expected_type, expected_code in [
+        (401, AuthError, "unauthorized"),
+        (503, UnavailableError, "unavailable"),
+        (404, ApiError, "not_found"),
+        (400, ApiError, "invalid_request"),
+        (500, ApiError, "unknown"),
+    ]:
+        for body in [b"", b"not json", b'{"error": "flat string"}', b'{"unrelated": true}']:
+            err = error_from_response(status, body)
+            assert isinstance(err, expected_type), (status, body)
+            assert err.status == status
+            assert err.code == expected_code, (status, body)
+
+
+def test_unavailable_error_carries_optional_status_for_network_failures() -> None:
+    err = UnavailableError("connection refused", status=None)
+    assert err.status is None
+    assert err.code == "unavailable"
+
+
+def test_config_error_is_a_distinct_type() -> None:
+    assert not issubclass(ConfigError, ApiError)
+    assert issubclass(ConfigError, Exception)

--- a/src/sdk/cloud-py/tests/test_fetch_catalog.py
+++ b/src/sdk/cloud-py/tests/test_fetch_catalog.py
@@ -1,0 +1,116 @@
+"""`fetch_catalog`: one conditional GET of a source's `/v1/catalog`, exercised
+against the conformant `MockSource` over real HTTP."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from ratel_ai import SourceConfig
+
+from ratel_ai_cloud.errors import ApiError, AuthError, UnavailableError
+from ratel_ai_cloud.fetch_catalog import CatalogChanged, CatalogUnchanged, fetch_catalog
+from ratel_ai_cloud.testing.mock_source import MockSource
+
+API_KEY = "test-key"
+
+
+@pytest.fixture()
+def source() -> Iterator[MockSource]:
+    with MockSource(api_key=API_KEY) as src:
+        yield src
+
+
+def _config(source: MockSource, scope: str | None = None) -> SourceConfig:
+    return SourceConfig(url=source.url, api_key=API_KEY, scope=scope)
+
+
+def _skill(skill_id: str, body: str = "b\n") -> dict[str, Any]:
+    return {
+        "id": skill_id,
+        "name": f"{skill_id}-name",
+        "description": f"{skill_id} description",
+        "tags": ["t"],
+        "tools": [],
+        "metadata": {},
+        "body": body,
+    }
+
+
+def test_changed_result_carries_etag_and_catalog(source: MockSource) -> None:
+    source.set_skills([_skill("a"), _skill("b")])
+    result = fetch_catalog(_config(source))
+    assert isinstance(result, CatalogChanged)
+    assert result.changed is True
+    assert result.etag == f'"{result.catalog.catalog_version}"'
+    assert [s["id"] for s in result.catalog.skills] == ["a", "b"]
+
+
+def test_sends_bearer_and_if_none_match(source: MockSource) -> None:
+    source.set_skills([_skill("a")])
+    first = fetch_catalog(_config(source))
+    assert isinstance(first, CatalogChanged)
+    second = fetch_catalog(_config(source), etag=first.etag)
+    assert isinstance(second, CatalogUnchanged)
+    assert second.changed is False
+    initial, revalidation = source.requests
+    assert initial.headers["authorization"] == f"Bearer {API_KEY}"
+    assert "if-none-match" not in initial.headers
+    assert revalidation.headers["authorization"] == f"Bearer {API_KEY}"
+    assert revalidation.headers["if-none-match"] == first.etag
+
+
+def test_scope_passes_through_and_selects_the_overlay(
+    source: MockSource, vectors: dict[str, Any]
+) -> None:
+    source.set_layers(vectors["catalogs"]["scoped"])
+    global_result = fetch_catalog(_config(source))
+    alice_result = fetch_catalog(_config(source, scope="alice"))
+    assert isinstance(global_result, CatalogChanged)
+    assert isinstance(alice_result, CatalogChanged)
+    assert global_result.etag != alice_result.etag
+    assert [s["id"] for s in alice_result.catalog.skills] == ["a-files", "g-email", "g-search"]
+    assert [r.scope for r in source.requests] == [None, "alice"]
+    # An etag cached for one scope must not be replayed into another.
+    cross = fetch_catalog(_config(source, scope="alice"), etag=global_result.etag)
+    assert isinstance(cross, CatalogChanged)
+
+
+def test_tolerates_a_trailing_slash_in_the_base_url(source: MockSource) -> None:
+    source.set_skills([_skill("a")])
+    config = SourceConfig(url=f"{source.url}/", api_key=API_KEY, scope=None)
+    result = fetch_catalog(config)
+    assert isinstance(result, CatalogChanged)
+    assert source.requests[-1].path == "/v1/catalog"
+
+
+def test_401_raises_auth_error(source: MockSource) -> None:
+    config = SourceConfig(url=source.url, api_key="wrong-key", scope=None)
+    with pytest.raises(AuthError) as excinfo:
+        fetch_catalog(config)
+    assert excinfo.value.status == 401
+    assert excinfo.value.code == "unauthorized"
+
+
+def test_503_raises_unavailable_error(source: MockSource) -> None:
+    source.inject_failure(503, code="unavailable")
+    with pytest.raises(UnavailableError) as excinfo:
+        fetch_catalog(_config(source))
+    assert excinfo.value.status == 503
+
+
+def test_other_statuses_raise_api_error_with_code(source: MockSource) -> None:
+    source.inject_failure(400, code="invalid_request")
+    with pytest.raises(ApiError) as excinfo:
+        fetch_catalog(_config(source))
+    assert excinfo.value.status == 400
+    assert excinfo.value.code == "invalid_request"
+
+
+def test_network_failure_raises_unavailable_error_without_status(source: MockSource) -> None:
+    config = _config(source)
+    source.stop()
+    with pytest.raises(UnavailableError) as excinfo:
+        fetch_catalog(config)
+    assert excinfo.value.status is None

--- a/src/sdk/cloud-py/tests/test_index.py
+++ b/src/sdk/cloud-py/tests/test_index.py
@@ -1,0 +1,129 @@
+"""Package entry points: `create_skill_sync` (offline-tolerant handle) and
+`sync_skills` (one-shot, raising), with explicit options beating the
+`RATEL_URL` / `RATEL_API_KEY` environment."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from ratel_ai import SkillCatalog
+
+import ratel_ai_cloud
+from ratel_ai_cloud import SkillSync, SyncResult, create_skill_sync, sync_skills
+from ratel_ai_cloud.errors import ConfigError, UnavailableError
+from ratel_ai_cloud.testing.mock_source import MockSource
+
+API_KEY = "test-key"
+
+
+@pytest.fixture()
+def source() -> Iterator[MockSource]:
+    with MockSource(api_key=API_KEY) as src:
+        src.set_skills([_wire("a")])
+        yield src
+
+
+def _wire(skill_id: str) -> dict[str, Any]:
+    return {
+        "id": skill_id,
+        "name": f"{skill_id}-name",
+        "description": f"{skill_id} description",
+        "tags": [],
+        "tools": [],
+        "metadata": {},
+        "body": f"# {skill_id}\n",
+    }
+
+
+def test_public_surface() -> None:
+    for name in ("create_skill_sync", "sync_skills", "SkillSync", "SyncResult"):
+        assert name in ratel_ai_cloud.__all__
+        assert hasattr(ratel_ai_cloud, name)
+
+
+def test_sync_skills_one_shot(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    result = sync_skills(catalog, url=source.url, api_key=API_KEY, env={})
+    assert result == SyncResult(added=1, updated=0, removed=0, conflicts=[], unchanged=False)
+    assert catalog.has("a")
+
+
+def test_sync_skills_raises_on_failure(source: MockSource) -> None:
+    source.inject_failure(503, code="unavailable")
+    with pytest.raises(UnavailableError):
+        sync_skills(SkillCatalog(), url=source.url, api_key=API_KEY, env={})
+
+
+def test_no_url_anywhere_raises_config_error() -> None:
+    with pytest.raises(ConfigError):
+        sync_skills(SkillCatalog(), env={})
+    with pytest.raises(ConfigError):
+        create_skill_sync(SkillCatalog(), env={})
+
+
+def test_env_resolution_and_explicit_precedence(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    env = {"RATEL_URL": source.url, "RATEL_API_KEY": API_KEY}
+    assert sync_skills(catalog, env=env).added == 1
+
+    # Explicit options beat the environment.
+    bad_env = {"RATEL_URL": "http://127.0.0.1:1", "RATEL_API_KEY": "nope"}
+    result = sync_skills(SkillCatalog(), url=source.url, api_key=API_KEY, env=bad_env)
+    assert result.added == 1
+
+
+def test_create_skill_sync_hydrates_and_returns_the_handle(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    sync = create_skill_sync(catalog, url=source.url, api_key=API_KEY, env={})
+    assert isinstance(sync, SkillSync)
+    assert catalog.has("a")
+    assert sync.owned_count == 1
+    assert sync.last_synced_at is not None
+    sync.stop()
+
+
+def test_create_skill_sync_scope_is_passed_through(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    sync = create_skill_sync(catalog, url=source.url, api_key=API_KEY, scope="alice", env={})
+    assert source.requests[-1].scope == "alice"
+    sync.stop()
+
+
+def test_create_skill_sync_is_offline_tolerant(source: MockSource) -> None:
+    source.inject_failure(503, code="unavailable")
+    catalog = SkillCatalog()
+    sync = create_skill_sync(catalog, url=source.url, api_key=API_KEY, env={})
+    assert catalog.size() == 0
+    assert sync.consecutive_failures == 1
+    assert sync.last_synced_at is None
+    # The source comes back: a manual refresh hydrates.
+    sync.refresh()
+    assert catalog.has("a")
+    sync.stop()
+
+
+def test_create_skill_sync_with_interval_keeps_refreshing(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    sync = create_skill_sync(catalog, url=source.url, api_key=API_KEY, interval_s=0.02, env={})
+    try:
+        source.set_skills([_wire("a"), _wire("b")])
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not catalog.has("b"):
+            time.sleep(0.01)
+        assert catalog.has("b")
+    finally:
+        sync.stop()
+
+
+def test_create_skill_sync_does_not_start_a_chain_after_auth_failure(source: MockSource) -> None:
+    source.inject_failure(401, code="unauthorized", times=10_000)
+    catalog = SkillCatalog()
+    sync = create_skill_sync(catalog, url=source.url, api_key=API_KEY, interval_s=0.02, env={})
+    assert sync.consecutive_failures == 1
+    requests_seen = len(source.requests)
+    time.sleep(0.15)
+    assert len(source.requests) == requests_seen
+    sync.stop()

--- a/src/sdk/cloud-py/tests/test_integration.py
+++ b/src/sdk/cloud-py/tests/test_integration.py
@@ -1,0 +1,88 @@
+"""End-to-end over real HTTP: a `MockSource` hydrates a real
+`ratel_ai.SkillCatalog`, and the capability tools surface the synced skills —
+discovery, live advertising, source-side removal, and the ownership rule."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from ratel_ai import Skill, SkillCatalog, ToolCatalog, search_capabilities_tool
+
+from ratel_ai_cloud import create_skill_sync
+from ratel_ai_cloud.testing.mock_source import MockSource
+
+API_KEY = "test-key"
+
+DEPLOY_SKILL: dict[str, Any] = {
+    "id": "deploy-frontend",
+    "name": "deploy-frontend",
+    "description": "Deploy the frontend app to production with smoke checks.",
+    "tags": ["deploy", "frontend"],
+    "tools": [],
+    "metadata": {"stacks": ["react"]},
+    "body": "# Deploy the frontend\n1. Build.\n2. Ship.\n",
+}
+
+
+@pytest.fixture()
+def source() -> Iterator[MockSource]:
+    with MockSource(api_key=API_KEY) as src:
+        src.set_skills([DEPLOY_SKILL])
+        yield src
+
+
+def _search(tool: Any, query: str) -> dict[str, Any]:
+    result: dict[str, Any] = asyncio.run(tool.execute({"query": query}))
+    return result
+
+
+def test_synced_skills_flow_through_the_capability_tools(source: MockSource) -> None:
+    skills = SkillCatalog()
+    search = search_capabilities_tool(ToolCatalog(), skills)
+
+    # Before hydration the tool advertises no skills bucket.
+    assert "get_skill_content" not in search.description
+
+    sync = create_skill_sync(skills, url=source.url, api_key=API_KEY, env={})
+
+    # The live description reflects the hydrated catalog without rebuilding.
+    assert "get_skill_content" in search.description
+
+    hits = _search(search, "deploy the frontend to production")["skills"]
+    assert [h["skillId"] for h in hits] == ["deploy-frontend"]
+    assert skills.invoke("deploy-frontend") == DEPLOY_SKILL["body"]
+
+    # A source-side removal disappears on the next refresh.
+    source.set_skills([])
+    sync.refresh()
+    assert not skills.has("deploy-frontend")
+    assert _search(search, "deploy the frontend to production")["skills"] == []
+    assert "get_skill_content" not in search.description
+    sync.stop()
+
+
+def test_host_collision_lands_in_conflicts_untouched(source: MockSource) -> None:
+    skills = SkillCatalog()
+    host_skill = Skill(
+        id="deploy-frontend",
+        name="host-deploy",
+        description="The host's own deploy playbook.",
+        body="host body\n",
+    )
+    skills.register(host_skill)
+
+    sync = create_skill_sync(skills, url=source.url, api_key=API_KEY, env={})
+    assert skills.get("deploy-frontend") == host_skill
+    assert sync.owned_count == 0
+
+    # A source-side change re-reports the conflict on the 200 path — and still
+    # never touches the host's skill.
+    source.set_skills([{**DEPLOY_SKILL, "body": "still not yours\n"}])
+    result = sync.refresh()
+    assert result.conflicts == ["deploy-frontend"]
+    assert skills.get("deploy-frontend") == host_skill
+    assert sync.owned_count == 0
+    sync.stop()

--- a/src/sdk/cloud-py/tests/test_mock_source.py
+++ b/src/sdk/cloud-py/tests/test_mock_source.py
@@ -1,0 +1,190 @@
+"""`MockSource` must behave like a conformant catalog source over real HTTP:
+every committed etag vector, all 7 If-None-Match outcomes, the frozen auth and
+error bodies, and the structural secrets rule."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from ratel_ai_cloud.canonical import SKILL_FIELDS
+from ratel_ai_cloud.testing.mock_source import MockSource
+
+API_KEY = "test-key"
+
+
+@pytest.fixture()
+def source() -> Iterator[MockSource]:
+    with MockSource(api_key=API_KEY) as src:
+        yield src
+
+
+def _get(
+    url: str,
+    api_key: str | None = API_KEY,
+    etag: str | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    request = urllib.request.Request(url)
+    if api_key is not None:
+        request.add_header("Authorization", f"Bearer {api_key}")
+    if etag is not None:
+        request.add_header("If-None-Match", etag)
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.status, dict(response.headers.items()), response.read()
+    except urllib.error.HTTPError as err:
+        return err.code, dict(err.headers.items()), err.read()
+
+
+def _catalog_url(source: MockSource, scope: str | None) -> str:
+    url = f"{source.url}/v1/catalog"
+    if scope is not None:
+        url += f"?scope={scope}"
+    return url
+
+
+def test_reproduces_every_etag_vector(source: MockSource, vectors: dict[str, Any]) -> None:
+    for vector in vectors["etag"]:
+        source.set_layers(vectors["catalogs"][vector["catalog"]])
+        status, headers, body = _get(_catalog_url(source, vector.get("scope")))
+        assert status == 200, vector["name"]
+        assert headers["ETag"] == vector["expect"]["etag"], vector["name"]
+        assert headers["Cache-Control"] == "no-cache"
+        payload = json.loads(body)
+        # Quoted strong tag in the header; bare hex in the body.
+        assert f'"{payload["catalogVersion"]}"' == vector["expect"]["etag"]
+        assert [s["id"] for s in payload["skills"]] == vector["expect"]["resolvedIds"]
+
+
+def _current_etag(source: MockSource, scope: str | None = None) -> str:
+    _, headers, _ = _get(_catalog_url(source, scope))
+    return headers["ETag"]
+
+
+def test_reproduces_every_inm_outcome(source: MockSource, vectors: dict[str, Any]) -> None:
+    etag_vectors = {v["name"]: v for v in vectors["etag"]}
+    for vector in vectors["inm"]:
+        current_vec = etag_vectors[vector["current"]]
+        source.set_layers(vectors["catalogs"][current_vec["catalog"]])
+        current_scope = current_vec.get("scope")
+        current = _current_etag(source, current_scope)
+        kind = vector["ifNoneMatch"]["kind"]
+        if kind == "self":
+            header: str | None = current
+        elif kind == "weakSelf":
+            header = f"W/{current}"
+        elif kind == "star":
+            header = "*"
+        elif kind == "listWithSelf":
+            header = f'"deadbeef", {current}'
+        elif kind == "listMiss":
+            header = '"deadbeef", "c0ffeec0ffeec0ffee"'
+        elif kind == "absent":
+            header = None
+        elif kind == "other":
+            other_vec = etag_vectors[vector["of"]]
+            header = _current_etag(source, other_vec.get("scope"))
+        else:  # pragma: no cover - vectors.json is frozen
+            raise AssertionError(f"unknown If-None-Match kind: {kind}")
+        status, _, body = _get(_catalog_url(source, current_scope), etag=header)
+        assert status == vector["expect"], vector["name"]
+        if status == 304:
+            assert body == b""
+
+
+def test_served_skills_carry_exactly_the_wire_fields(
+    source: MockSource, vectors: dict[str, Any]
+) -> None:
+    wire = vectors["wire"]
+    noisy = {
+        "id": "s",
+        "name": "n",
+        "description": "d",
+        "tags": [],
+        "tools": [],
+        "metadata": {},
+        "body": "b",
+        "status": "published",
+        "apiKey": "sk-LEAK",
+        "authorization": "Bearer LEAK",
+    }
+    source.set_skills([noisy])
+    _, _, body = _get(_catalog_url(source, None))
+    for skill in json.loads(body)["skills"]:
+        assert list(skill.keys()) == wire["skillFields"] == list(SKILL_FIELDS)
+        for field in skill:
+            for forbidden in wire["forbiddenFieldSubstrings"]:
+                assert forbidden not in field.lower()
+    assert b"LEAK" not in body
+
+
+def test_missing_or_bad_bearer_yields_frozen_401_body(source: MockSource) -> None:
+    for key in (None, "wrong-key"):
+        status, _, body = _get(_catalog_url(source, None), api_key=key)
+        assert status == 401
+        payload = json.loads(body)
+        assert set(payload.keys()) == {"error"}
+        assert payload["error"]["code"] == "unauthorized"
+        assert isinstance(payload["error"]["message"], str)
+
+
+def test_healthz_is_unauthenticated(source: MockSource) -> None:
+    status, _, _ = _get(f"{source.url}/healthz", api_key=None)
+    assert status == 200
+
+
+def test_unknown_v1_path_yields_frozen_404_body(source: MockSource) -> None:
+    status, _, body = _get(f"{source.url}/v1/nope")
+    assert status == 404
+    assert json.loads(body)["error"]["code"] == "not_found"
+
+
+def test_records_requests(source: MockSource) -> None:
+    _get(_catalog_url(source, "alice"), etag='"abc"')
+    _get(f"{source.url}/healthz", api_key=None)
+    catalog_req, healthz_req = source.requests
+    assert catalog_req.method == "GET"
+    assert catalog_req.path == "/v1/catalog"
+    assert catalog_req.scope == "alice"
+    assert catalog_req.headers["authorization"] == f"Bearer {API_KEY}"
+    assert catalog_req.headers["if-none-match"] == '"abc"'
+    assert healthz_req.path == "/healthz"
+    assert healthz_req.scope is None
+
+
+def test_set_skills_replaces_the_global_layer(source: MockSource) -> None:
+    source.set_skills([_skill("a")])
+    first = _current_etag(source)
+    source.set_skills([_skill("a"), _skill("b")])
+    second = _current_etag(source)
+    assert first != second
+    _, _, body = _get(_catalog_url(source, None))
+    assert [s["id"] for s in json.loads(body)["skills"]] == ["a", "b"]
+
+
+def test_failure_injection_then_recovery(source: MockSource) -> None:
+    source.set_skills([_skill("a")])
+    source.inject_failure(503, code="unavailable", times=2)
+    for _ in range(2):
+        status, _, body = _get(_catalog_url(source, None))
+        assert status == 503
+        assert json.loads(body)["error"]["code"] == "unavailable"
+    status, _, _ = _get(_catalog_url(source, None))
+    assert status == 200
+
+
+def _skill(skill_id: str) -> dict[str, Any]:
+    return {
+        "id": skill_id,
+        "name": f"{skill_id}-name",
+        "description": f"{skill_id} description",
+        "tags": [],
+        "tools": [],
+        "metadata": {},
+        "body": f"# {skill_id}\n",
+    }

--- a/src/sdk/cloud-py/tests/test_skill_sync.py
+++ b/src/sdk/cloud-py/tests/test_skill_sync.py
@@ -1,0 +1,280 @@
+"""`SkillSync`: refresh diffing under the ownership rule, 304 revalidation,
+and the jittered timer chain — against the conformant `MockSource`."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+
+import pytest
+from ratel_ai import Skill, SkillCatalog, SourceConfig
+
+from ratel_ai_cloud.errors import UnavailableError
+from ratel_ai_cloud.fetch_catalog import FetchCatalogResult, fetch_catalog
+from ratel_ai_cloud.skill_sync import SkillSync, SyncResult, _jittered_interval
+from ratel_ai_cloud.testing.mock_source import MockSource
+
+API_KEY = "test-key"
+
+
+@pytest.fixture()
+def source() -> Iterator[MockSource]:
+    with MockSource(api_key=API_KEY) as src:
+        yield src
+
+
+def _config(source: MockSource, scope: str | None = None) -> SourceConfig:
+    return SourceConfig(url=source.url, api_key=API_KEY, scope=scope)
+
+
+def _wire(skill_id: str, body: str | None = None, **extra: Any) -> dict[str, Any]:
+    return {
+        "id": skill_id,
+        "name": f"{skill_id}-name",
+        "description": f"{skill_id} description",
+        "tags": ["t"],
+        "tools": [],
+        "metadata": {},
+        "body": body if body is not None else f"# {skill_id}\n",
+        **extra,
+    }
+
+
+def _wait_until(predicate: Any, timeout_s: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not reached in time")
+
+
+def test_refresh_hydrates_and_projects_to_the_seven_fields(source: MockSource) -> None:
+    source.set_skills([_wire("a"), _wire("b")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+
+    result = sync.refresh()
+    assert result == SyncResult(added=2, updated=0, removed=0, conflicts=[], unchanged=False)
+    assert catalog.size() == 2
+    skill = catalog.get("a")
+    assert isinstance(skill, Skill)
+    assert skill.name == "a-name"
+    assert skill.body == "# a\n"
+    assert sync.owned_count == 2
+    assert isinstance(sync.last_synced_at, datetime)
+    assert sync.consecutive_failures == 0
+
+
+def test_refresh_is_serialized_by_a_lock(source: MockSource) -> None:
+    active = 0
+    max_active = 0
+
+    def slow_fetch(config: SourceConfig, etag: str | None) -> FetchCatalogResult:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        time.sleep(0.05)
+        result = fetch_catalog(config, etag)
+        active -= 1
+        return result
+
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source), fetch_impl=slow_fetch)
+    threads = [threading.Thread(target=sync.refresh) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert max_active == 1
+    assert catalog.size() == 1
+
+
+def test_identical_resync_emits_zero_churn(source: MockSource) -> None:
+    source.set_skills([_wire("a"), _wire("b")])
+    catalog = SkillCatalog()
+    # Drop the cached etag so the resync takes the 200 path (not a 304): the
+    # idempotence gate must hold even on a full re-download of identical data.
+    sync = SkillSync(
+        catalog, _config(source), fetch_impl=lambda config, etag: fetch_catalog(config, None)
+    )
+    sync.refresh()
+
+    churn: list[None] = []
+    catalog.on_change(lambda: churn.append(None))
+    result = sync.refresh()
+    assert churn == []
+    assert result == SyncResult(added=0, updated=0, removed=0, conflicts=[], unchanged=False)
+
+
+def test_upserts_only_the_skill_whose_projection_changed(source: MockSource) -> None:
+    source.set_skills([_wire("a"), _wire("b")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.refresh()
+
+    source.set_skills([_wire("a", body="changed\n"), _wire("b")])
+    result = sync.refresh()
+    assert result == SyncResult(added=0, updated=1, removed=0, conflicts=[], unchanged=False)
+    skill = catalog.get("a")
+    assert skill is not None and skill.body == "changed\n"
+
+
+def test_wire_noise_fields_do_not_defeat_the_idempotence_gate(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(
+        catalog, _config(source), fetch_impl=lambda config, etag: fetch_catalog(config, None)
+    )
+    sync.refresh()
+
+    # The mock's projection strips unknown fields; even if a source leaked
+    # noise, the 7-field equality gate keeps the resync churn-free.
+    source.set_skills([_wire("a", createdAt="2026-01-01T00:00:00Z")])
+    result = sync.refresh()
+    assert result == SyncResult(added=0, updated=0, removed=0, conflicts=[], unchanged=False)
+
+
+def test_removes_and_disowns_an_owned_id_that_left_the_wire(source: MockSource) -> None:
+    source.set_skills([_wire("a"), _wire("b")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.refresh()
+
+    source.set_skills([_wire("b")])
+    result = sync.refresh()
+    assert result == SyncResult(added=0, updated=0, removed=1, conflicts=[], unchanged=False)
+    assert not catalog.has("a")
+    assert sync.owned_count == 1
+
+
+def test_never_touches_a_host_skill_with_a_colliding_id(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    catalog.register(Skill(id="a", name="host-owned", description="host", body="host body"))
+    source.set_skills([_wire("a"), _wire("b")])
+    sync = SkillSync(catalog, _config(source))
+
+    result = sync.refresh()
+    assert result == SyncResult(added=1, updated=0, removed=0, conflicts=["a"], unchanged=False)
+    skill = catalog.get("a")
+    assert skill is not None and skill.name == "host-owned"
+    assert sync.owned_count == 1
+
+    # The conflicting id is never adopted, upserted, or disowned into a removal.
+    source.set_skills([_wire("a", body="still not yours\n"), _wire("b")])
+    again = sync.refresh()
+    assert again.conflicts == ["a"]
+    assert again.updated == 0 and again.removed == 0
+    skill = catalog.get("a")
+    assert skill is not None and skill.name == "host-owned"
+
+
+def test_304_is_a_revalidated_noop_that_refreshes_last_synced_at(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.refresh()
+    first_synced_at = sync.last_synced_at
+    assert first_synced_at is not None
+
+    churn: list[None] = []
+    catalog.on_change(lambda: churn.append(None))
+    time.sleep(0.01)
+    result = sync.refresh()
+    assert result == SyncResult(added=0, updated=0, removed=0, conflicts=[], unchanged=True)
+    assert churn == []
+    assert catalog.size() == 1
+    assert sync.last_synced_at is not None and sync.last_synced_at > first_synced_at
+    # The revalidation carried the cached etag for this (url, scope).
+    assert source.requests[-1].headers["if-none-match"].strip('"') != ""
+
+
+def test_transient_failure_keeps_the_replica_and_counts(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.refresh()
+
+    source.inject_failure(503, code="unavailable", times=2)
+    for expected_failures in (1, 2):
+        with pytest.raises(UnavailableError):
+            sync.refresh()
+        assert sync.consecutive_failures == expected_failures
+        assert catalog.size() == 1  # the last-pulled replica stays live
+
+    sync.refresh()
+    assert sync.consecutive_failures == 0
+
+
+def test_jittered_interval_stays_within_ten_percent() -> None:
+    samples = [_jittered_interval(10.0) for _ in range(200)]
+    assert all(9.0 <= s <= 11.0 for s in samples)
+    assert len(set(samples)) > 1
+
+
+def test_start_keeps_refreshing_on_a_timer(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.start(0.02)
+    try:
+        _wait_until(lambda: catalog.has("a"))
+        assert sync._timer is not None and sync._timer.daemon  # timers never pin the process
+        source.set_skills([_wire("a"), _wire("b")])
+        _wait_until(lambda: catalog.has("b"))
+        source.set_skills([_wire("b")])
+        _wait_until(lambda: not catalog.has("a"))
+    finally:
+        sync.stop()
+
+
+def test_transient_errors_keep_the_chain_alive(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    source.inject_failure(503, code="unavailable", times=3)
+    sync.start(0.02)
+    try:
+        _wait_until(lambda: sync.consecutive_failures > 0)
+        _wait_until(lambda: catalog.has("a"))  # chain survived and recovered
+        assert sync.consecutive_failures == 0
+    finally:
+        sync.stop()
+
+
+def test_auth_error_stops_the_chain_permanently(source: MockSource) -> None:
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    source.inject_failure(401, code="unauthorized", times=10_000)
+    sync.start(0.02)
+    _wait_until(lambda: sync.consecutive_failures > 0)
+    _wait_until(lambda: sync._timer is None)
+    requests_after_stop = len(source.requests)
+    time.sleep(0.1)
+    assert len(source.requests) == requests_after_stop
+    # A permanently stopped chain cannot be restarted.
+    sync.start(0.02)
+    time.sleep(0.1)
+    assert len(source.requests) == requests_after_stop
+
+
+def test_stop_is_idempotent_and_race_safe(source: MockSource) -> None:
+    source.set_skills([_wire("a")])
+    catalog = SkillCatalog()
+    sync = SkillSync(catalog, _config(source))
+    sync.start(0.01)
+    _wait_until(lambda: catalog.has("a"))
+    threads = [threading.Thread(target=sync.stop) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    sync.stop()
+    time.sleep(0.05)
+    requests_after_stop = len(source.requests)
+    time.sleep(0.1)
+    assert len(source.requests) == requests_after_stop

--- a/src/sdk/cloud/CHANGELOG.md
+++ b/src/sdk/cloud/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to `@ratel-ai/cloud` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this package adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Initial package: the pull-sync loader for a networked catalog source over the frozen protocol/v1 contract. `createSkillSync()` attaches a source to a `SkillCatalog` and returns a handle (periodic `setTimeout` refresh chain with jitter, offline-tolerant first fetch, `lastSyncedAt` / `consecutiveFailures` staleness signals); `syncSkills()` is the one-shot variant. Synced skills are owned by the loader — host-registered skills are never touched and surface in `SyncResult.conflicts`. Conditional GET with the frozen ETag algorithm, per-`(url, scope)` cache, typed error taxonomy, and a vector-pinned in-process mock source under `@ratel-ai/cloud/testing`.

--- a/src/sdk/cloud/LICENSE.md
+++ b/src/sdk/cloud/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Agentified
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/sdk/cloud/README.md
+++ b/src/sdk/cloud/README.md
@@ -1,0 +1,60 @@
+# `@ratel-ai/cloud`
+
+Pull-sync loader for a networked catalog source, speaking the frozen
+[protocol/v1](../../../protocol/v1/README.md) contract: conditional `GET /v1/catalog` with the
+frozen ETag algorithm, Bearer auth, and an opaque `?scope=` selector. `createSkillSync()`
+attaches a source to a [`@ratel-ai/sdk`](../ts/README.md) `SkillCatalog` and returns a running
+handle; retrieval (the capability tools) stays entirely local over the hydrated replica
+([ADR-0003](../../../docs/adr/0003-catalog-source-interface.md)).
+
+## Usage
+
+```ts
+import { SkillCatalog } from "@ratel-ai/sdk";
+import { createSkillSync } from "@ratel-ai/cloud";
+
+const catalog = new SkillCatalog();
+
+// Resolves RATEL_URL / RATEL_API_KEY from the environment (explicit options win).
+const sync = createSkillSync(catalog); // immediate first refresh + periodic chain
+// ... sync.lastSyncedAt / sync.consecutiveFailures surface staleness; sync.stop() detaches.
+```
+
+`syncSkills(catalog, options?)` is the one-shot variant — it throws on any failure, while
+`createSkillSync` tolerates an unreachable source (the replica runs degraded and staleness is
+surfaced on the handle).
+
+Synced skills are **owned by the loader**: a host-registered skill with a colliding id is never
+touched and is reported in `SyncResult.conflicts`. A full resync of identical data emits zero
+catalog churn.
+
+## Layout
+
+```
+src/
+  canonical.ts        frozen v1 content projection, ETag, scope-overlay resolver
+  errors.ts           typed error taxonomy over the frozen error body
+  fetch-catalog.ts    one conditional GET of /v1/catalog
+  skill-sync.ts       SkillSync: refresh diffing (ownership rule) + timer chain
+  index.ts            createSkillSync / syncSkills entry points
+  testing/            in-process mock source (`@ratel-ai/cloud/testing`)
+```
+
+## Package shape
+
+- Package name: `@ratel-ai/cloud`
+- Pure TypeScript (no native binding); depends on `@ratel-ai/sdk`
+- MIT ([ADR-0009](../../../docs/adr/0009-licensing.md)); member of the pnpm workspace
+- The canonicalizer, the mock source, and the loader are pinned against
+  [`protocol/v1/conformance/vectors.json`](../../../protocol/v1/conformance/vectors.json)
+
+## Build & test
+
+From the repo root:
+
+```bash
+pnpm --filter @ratel-ai/cloud build
+pnpm --filter @ratel-ai/cloud typecheck
+pnpm --filter @ratel-ai/cloud lint
+pnpm --filter @ratel-ai/cloud test
+```

--- a/src/sdk/cloud/package.json
+++ b/src/sdk/cloud/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@ratel-ai/cloud",
+  "version": "0.1.0-rc.1",
+  "description": "Ratel cloud catalog-source loader — pull-syncs published skills into a local SkillCatalog over the frozen protocol/v1 contract.",
+  "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/mock-source.d.ts",
+      "default": "./dist/testing/mock-source.js"
+    }
+  },
+  "license": "MIT",
+  "author": "Agentified",
+  "homepage": "https://github.com/ratel-ai/ratel",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ratel-ai/ratel.git",
+    "directory": "src/sdk/cloud"
+  },
+  "bugs": {
+    "url": "https://github.com/ratel-ai/ratel/issues"
+  },
+  "keywords": [
+    "skills",
+    "catalog",
+    "pull-sync",
+    "context-engineering",
+    "ai-agents",
+    "ratel"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "files": [
+    "dist",
+    "LICENSE.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "dependencies": {
+    "@ratel-ai/sdk": "workspace:^"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
+    "@types/node": "^24.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/src/sdk/cloud/src/canonical.test.ts
+++ b/src/sdk/cloud/src/canonical.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  canonicalSet,
+  canonicalSkill,
+  etagOf,
+  resolveScope,
+  type SourceLayers,
+  skillsEqual,
+} from "./canonical.js";
+
+const VECTORS_URL = new URL("../../../../protocol/v1/conformance/vectors.json", import.meta.url);
+
+interface EtagVector {
+  name: string;
+  catalog: string;
+  scope: string | null;
+  expect: { resolvedIds: string[]; etag: string };
+}
+
+interface VectorsDoc {
+  catalogs: Record<string, SourceLayers>;
+  etag: EtagVector[];
+  equalEtags: string[][];
+  distinctEtags: string[][];
+}
+
+const doc: VectorsDoc = JSON.parse(readFileSync(VECTORS_URL, "utf8"));
+
+const skill = {
+  id: "a-skill",
+  name: "alpha-tool",
+  description: "First tool.",
+  tags: ["x", "y"],
+  tools: ["t1"],
+  metadata: { cat: ["a"] },
+  body: "# Alpha\n",
+};
+
+describe("canonicalSkill", () => {
+  it("emits exactly the 7 wire fields in the fixed key order", () => {
+    expect(canonicalSkill(skill)).toBe(
+      '{"id":"a-skill","name":"alpha-tool","description":"First tool.","tags":["x","y"],' +
+        '"tools":["t1"],"metadata":{"cat":["a"]},"body":"# Alpha\\n"}',
+    );
+  });
+
+  it("drops every non-wire field from the projection", () => {
+    const noisy = { ...skill, createdAt: "2026-01-01T00:00:00Z", version: 7, status: "published" };
+    expect(canonicalSkill(noisy)).toBe(canonicalSkill(skill));
+  });
+
+  it("sorts metadata keys by UTF-8 byte order and keeps value arrays authored", () => {
+    const s = { ...skill, metadata: { cat: ["b", "a"], area: ["core"] } };
+    expect(canonicalSkill(s)).toContain('"metadata":{"area":["core"],"cat":["b","a"]}');
+  });
+
+  it("keeps tags and tools in authored order", () => {
+    expect(canonicalSkill({ ...skill, tags: ["y", "x"] })).not.toBe(canonicalSkill(skill));
+  });
+
+  it("emits non-ASCII as raw UTF-8, never \\u escapes", () => {
+    const s = { ...skill, description: "café ☕", metadata: { área: ["café"] } };
+    const canonical = canonicalSkill(s);
+    expect(canonical).toContain("café ☕");
+    expect(canonical).toContain('"área":["café"]');
+    expect(canonical).not.toMatch(/\\u/);
+  });
+
+  it("defaults absent optional fields — parity with the SDK Skill shape", () => {
+    const minimal = { id: "m", name: "min", description: "d" };
+    expect(canonicalSkill(minimal)).toBe(
+      '{"id":"m","name":"min","description":"d","tags":[],"tools":[],"metadata":{},"body":""}',
+    );
+  });
+});
+
+describe("canonicalSet", () => {
+  it("sorts skills by id and joins them into a compact JSON array", () => {
+    const other = { ...skill, id: "b-skill" };
+    expect(canonicalSet([other, skill])).toBe(
+      `[${canonicalSkill(skill)},${canonicalSkill(other)}]`,
+    );
+  });
+
+  it("hashes an empty catalog as the two bytes []", () => {
+    expect(canonicalSet([])).toBe("[]");
+    expect(etagOf([]).hex).toBe("4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945");
+  });
+});
+
+describe("etagOf", () => {
+  it("returns the lowercase hex sha256 and the quoted strong tag", () => {
+    const { hex, etag } = etagOf([skill]);
+    expect(hex).toMatch(/^[0-9a-f]{64}$/);
+    expect(etag).toBe(`"${hex}"`);
+  });
+});
+
+describe("resolveScope", () => {
+  const layers: SourceLayers = {
+    global: [
+      { ...skill, id: "g1", name: "search-web" },
+      { ...skill, id: "g2", name: "send-email" },
+    ],
+    subjects: {
+      alice: [
+        { ...skill, id: "z-override", name: "search-web", body: "alice\n" },
+        { ...skill, id: "a-extra", name: "list-files" },
+      ],
+    },
+  };
+
+  it("returns the global layer only when scope is absent", () => {
+    expect(resolveScope(layers, null).map((s) => s.id)).toEqual(["g1", "g2"]);
+    expect(resolveScope(layers, undefined).map((s) => s.id)).toEqual(["g1", "g2"]);
+  });
+
+  it("returns the global layer for an unknown subject", () => {
+    expect(resolveScope(layers, "nobody").map((s) => s.id)).toEqual(["g1", "g2"]);
+  });
+
+  it("overlays the subject layer, subject wins on name collision, re-sorted by id", () => {
+    const resolved = resolveScope(layers, "alice");
+    expect(resolved.map((s) => s.id)).toEqual(["a-extra", "g2", "z-override"]);
+    expect(resolved.find((s) => s.name === "search-web")?.body).toBe("alice\n");
+  });
+});
+
+describe("skillsEqual", () => {
+  it("compares exactly the 7 wire fields", () => {
+    expect(skillsEqual(skill, { ...skill, extra: "noise" })).toBe(true);
+    expect(skillsEqual(skill, { ...skill, body: "changed" })).toBe(false);
+    expect(skillsEqual(skill, { ...skill, tags: ["y", "x"] })).toBe(false);
+  });
+});
+
+describe("protocol/v1 conformance vectors", () => {
+  // Iterate the committed file dynamically so new vectors are picked up.
+  const byName = new Map<string, string>();
+  for (const v of doc.etag) {
+    const resolved = resolveScope(doc.catalogs[v.catalog], v.scope);
+    byName.set(v.name, etagOf(resolved).etag);
+  }
+
+  it.each(
+    doc.etag.map((v) => [v.name, v] as const),
+  )("etag vector %s: resolvedIds and exact etag", (_name, v) => {
+    const resolved = resolveScope(doc.catalogs[v.catalog], v.scope);
+    expect(resolved.map((s) => s.id)).toEqual(v.expect.resolvedIds);
+    expect(etagOf(resolved).etag).toBe(v.expect.etag);
+  });
+
+  it.each(
+    doc.equalEtags.map((g) => [g.join("+"), g] as const),
+  )("equalEtags group %s", (_label, group) => {
+    const tags = group.map((n) => byName.get(n));
+    expect(tags.every((t) => t !== undefined)).toBe(true);
+    expect(new Set(tags).size).toBe(1);
+  });
+
+  it.each(
+    doc.distinctEtags.map((g) => [g.join("+"), g] as const),
+  )("distinctEtags group %s", (_label, group) => {
+    const tags = group.map((n) => byName.get(n));
+    expect(tags.every((t) => t !== undefined)).toBe(true);
+    expect(new Set(tags).size).toBe(group.length);
+  });
+
+  it("covers every vector in the file (none skipped)", () => {
+    expect(doc.etag.length).toBeGreaterThan(0);
+    expect(doc.equalEtags.length).toBeGreaterThan(0);
+    expect(doc.distinctEtags.length).toBeGreaterThan(0);
+  });
+});

--- a/src/sdk/cloud/src/canonical.ts
+++ b/src/sdk/cloud/src/canonical.ts
@@ -1,0 +1,111 @@
+/**
+ * The frozen protocol/v1 content projection and ETag algorithm
+ * (`protocol/v1/README.md`, pinned by `protocol/v1/conformance/vectors.json`).
+ * Reimplemented here — the reference verifier is not importable — and pinned
+ * against the committed vectors in `canonical.test.ts`. Changing any byte of
+ * this serialization is a protocol v2.
+ */
+
+import { createHash } from "node:crypto";
+
+/** The wire shape of one skill in a v1 catalog pull (`catalog-skill.schema.json`). */
+export interface CatalogSkillWire {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  tools: string[];
+  metadata: Record<string, string[]>;
+  body: string;
+}
+
+/**
+ * Anything projectable to the wire shape: the SDK `Skill` (optional fields) and
+ * any raw source-side object carrying extra fields the projection drops.
+ */
+export interface SkillLike {
+  id: string;
+  name: string;
+  description: string;
+  tags?: string[];
+  tools?: string[];
+  metadata?: Record<string, string[]>;
+  body?: string;
+}
+
+/** Source-side layers a scope resolves against: one global set plus per-subject overlays. */
+export interface SourceLayers {
+  global: CatalogSkillWire[];
+  subjects?: Record<string, CatalogSkillWire[]>;
+}
+
+// UTF-8 bytewise comparison, for the set sort-by-id and the metadata key sort.
+function byteCompare(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+/** Project a skill to exactly the 7 wire fields, defaulting the SDK's optional ones. */
+export function projectSkill(skill: SkillLike): CatalogSkillWire {
+  return {
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    tags: skill.tags ?? [],
+    tools: skill.tools ?? [],
+    metadata: skill.metadata ?? {},
+    body: skill.body ?? "",
+  };
+}
+
+/**
+ * Canonical JSON for one projected skill: the 7 keys in fixed order, metadata
+ * keys byte-sorted, arrays in authored order, minimal escaping, raw UTF-8, no
+ * whitespace. `JSON.stringify` on strings/arrays already emits minimal escapes
+ * and raw UTF-8; key order is driven by hand so object iteration order can
+ * never influence the bytes.
+ */
+export function canonicalSkill(skill: SkillLike): string {
+  const p = projectSkill(skill);
+  const s = JSON.stringify;
+  const metaKeys = Object.keys(p.metadata).sort(byteCompare);
+  const meta = `{${metaKeys.map((k) => `${s(k)}:${s(p.metadata[k])}`).join(",")}}`;
+  return (
+    `{"id":${s(p.id)},"name":${s(p.name)},"description":${s(p.description)},` +
+    `"tags":${s(p.tags)},"tools":${s(p.tools)},"metadata":${meta},"body":${s(p.body)}}`
+  );
+}
+
+/** Canonical bytes for a resolved set: skills sorted by id, compact JSON array. */
+export function canonicalSet(skills: SkillLike[]): string {
+  const sorted = [...skills].sort((a, b) => byteCompare(a.id, b.id));
+  return `[${sorted.map(canonicalSkill).join(",")}]`;
+}
+
+/** ETag over a resolved set: lowercase hex sha256 plus the quoted strong tag. */
+export function etagOf(skills: SkillLike[]): { hex: string; etag: string } {
+  const hex = createHash("sha256").update(canonicalSet(skills), "utf8").digest("hex");
+  return { hex, etag: `"${hex}"` };
+}
+
+/**
+ * Resolve the published set for a scope: absent scope or unknown subject means
+ * the global layer only; a known subject overlays its layer on the global one,
+ * the subject winning on `name` collision (the merge key is name, not id).
+ * The merged set is re-sorted by id.
+ */
+export function resolveScope(layers: SourceLayers, scope?: string | null): CatalogSkillWire[] {
+  const global = layers.global ?? [];
+  const sortById = (skills: CatalogSkillWire[]) =>
+    [...skills].sort((a, b) => byteCompare(a.id, b.id));
+  if (scope == null) return sortById(global);
+  const subject = layers.subjects?.[scope] ?? [];
+  const byName = new Map<string, CatalogSkillWire>();
+  for (const sk of global) byName.set(sk.name, sk);
+  for (const sk of subject) byName.set(sk.name, sk);
+  return sortById([...byName.values()]);
+}
+
+/** True when two skills agree on exactly the 7 wire fields — the sync idempotence gate. */
+export function skillsEqual(a: SkillLike, b: SkillLike): boolean {
+  return canonicalSkill(a) === canonicalSkill(b);
+}

--- a/src/sdk/cloud/src/errors.test.ts
+++ b/src/sdk/cloud/src/errors.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  CloudApiError,
+  CloudAuthError,
+  CloudConfigError,
+  CloudUnavailableError,
+  errorFromResponse,
+} from "./errors.js";
+
+const body = (code: string, message = "boom", details?: object) =>
+  JSON.stringify({ error: { code, message, ...(details ? { details } : {}) } });
+
+describe("errorFromResponse", () => {
+  it("maps 401 to CloudAuthError", () => {
+    const err = errorFromResponse(401, body("unauthorized", "bad key"));
+    expect(err).toBeInstanceOf(CloudAuthError);
+    expect(err.message).toContain("bad key");
+  });
+
+  it("maps 503 to CloudUnavailableError", () => {
+    const err = errorFromResponse(503, body("unavailable"));
+    expect(err).toBeInstanceOf(CloudUnavailableError);
+  });
+
+  it("maps 400 and 404 to CloudApiError with status and code", () => {
+    const bad = errorFromResponse(400, body("invalid_request"));
+    expect(bad).toBeInstanceOf(CloudApiError);
+    expect((bad as CloudApiError).status).toBe(400);
+    expect((bad as CloudApiError).code).toBe("invalid_request");
+
+    const missing = errorFromResponse(404, body("not_found"));
+    expect((missing as CloudApiError).status).toBe(404);
+    expect((missing as CloudApiError).code).toBe("not_found");
+  });
+
+  it("maps an unexpected status to CloudApiError", () => {
+    const err = errorFromResponse(418, body("invalid_request"));
+    expect(err).toBeInstanceOf(CloudApiError);
+    expect((err as CloudApiError).status).toBe(418);
+  });
+
+  it("falls back to the HTTP status on a malformed error body", () => {
+    expect(errorFromResponse(401, "not json at all")).toBeInstanceOf(CloudAuthError);
+    expect(errorFromResponse(503, '{"nope":true}')).toBeInstanceOf(CloudUnavailableError);
+    const err = errorFromResponse(500, "");
+    expect(err).toBeInstanceOf(CloudApiError);
+    expect((err as CloudApiError).status).toBe(500);
+    expect((err as CloudApiError).code).toBeUndefined();
+  });
+
+  it("ignores an error code that is not a string", () => {
+    const err = errorFromResponse(400, JSON.stringify({ error: { code: 42, message: "x" } }));
+    expect((err as CloudApiError).code).toBeUndefined();
+  });
+});
+
+describe("error classes", () => {
+  it("carry stable names for instanceof-free matching", () => {
+    expect(new CloudConfigError("x").name).toBe("CloudConfigError");
+    expect(new CloudAuthError("x").name).toBe("CloudAuthError");
+    expect(new CloudApiError("x", 400).name).toBe("CloudApiError");
+    expect(new CloudUnavailableError("x").name).toBe("CloudUnavailableError");
+  });
+});

--- a/src/sdk/cloud/src/errors.ts
+++ b/src/sdk/cloud/src/errors.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed error taxonomy for the loader, mapped from the frozen v1 error body
+ * `{ error: { code, message, details? } }` (`protocol/v1/schema/error.schema.json`).
+ * A malformed body falls back to the HTTP status alone.
+ */
+
+/** No source is configured / the configuration is unusable. Fails fast, never retried. */
+export class CloudConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudConfigError";
+  }
+}
+
+/** 401 — missing, malformed, unknown, or revoked key. Terminal for a sync chain. */
+export class CloudAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudAuthError";
+  }
+}
+
+/** Any other non-2xx the source answered with (400, 404, unexpected statuses). */
+export class CloudApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "CloudApiError";
+    this.status = status;
+    if (code !== undefined) this.code = code;
+  }
+}
+
+/** 503 or a network-level failure — the source is unreachable; the replica stays live. */
+export class CloudUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "CloudUnavailableError";
+  }
+}
+
+/** Parse the frozen error body, tolerating malformed bodies (HTTP status wins). */
+export function errorFromResponse(status: number, bodyText: string): Error {
+  let code: string | undefined;
+  let message = `catalog source responded ${status}`;
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    const error = (parsed as { error?: { code?: unknown; message?: unknown } }).error;
+    if (typeof error?.code === "string") code = error.code;
+    if (typeof error?.message === "string") message = `${message}: ${error.message}`;
+  } catch {
+    // Malformed error body — fall back to the HTTP status.
+  }
+  if (status === 401) return new CloudAuthError(message);
+  if (status === 503) return new CloudUnavailableError(message);
+  return new CloudApiError(message, status, code);
+}

--- a/src/sdk/cloud/src/fetch-catalog.test.ts
+++ b/src/sdk/cloud/src/fetch-catalog.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { CatalogSkillWire } from "./canonical.js";
+import { CloudApiError, CloudAuthError, CloudUnavailableError } from "./errors.js";
+import { fetchCatalog } from "./fetch-catalog.js";
+import { type MockSource, startMockSource } from "./testing/mock-source.js";
+
+const API_KEY = "test-key";
+
+const skill: CatalogSkillWire = {
+  id: "s1",
+  name: "alpha",
+  description: "First.",
+  tags: ["x"],
+  tools: [],
+  metadata: {},
+  body: "# A\n",
+};
+
+let source: MockSource;
+
+beforeAll(async () => {
+  source = await startMockSource({ apiKey: API_KEY });
+});
+
+afterAll(async () => {
+  await source.close();
+});
+
+beforeEach(() => {
+  source.setSkills([skill]);
+  source.failWith("catalog", undefined);
+  source.requests.length = 0;
+});
+
+describe("fetchCatalog", () => {
+  it("GETs <url>/v1/catalog with the Bearer header and returns the changed catalog", async () => {
+    const result = await fetchCatalog({ url: source.url, apiKey: API_KEY });
+    expect(result.changed).toBe(true);
+    if (!result.changed) throw new Error("unreachable");
+    expect(result.catalog.skills.map((s) => s.id)).toEqual(["s1"]);
+    expect(result.etag).toBe(`"${result.catalog.catalogVersion}"`);
+    expect(source.requests[0]).toMatchObject({
+      path: "/v1/catalog",
+      scope: null,
+      ifNoneMatch: null,
+      authorization: `Bearer ${API_KEY}`,
+    });
+  });
+
+  it("tolerates a trailing slash on the base url", async () => {
+    const result = await fetchCatalog({ url: `${source.url}/`, apiKey: API_KEY });
+    expect(result.changed).toBe(true);
+    expect(source.requests[0]?.path).toBe("/v1/catalog");
+  });
+
+  it("passes the configured scope through as ?scope=", async () => {
+    await fetchCatalog({ url: source.url, apiKey: API_KEY, scope: "alice" });
+    expect(source.requests[0]?.scope).toBe("alice");
+  });
+
+  it("sends If-None-Match when an etag is known and reports unchanged on 304", async () => {
+    const first = await fetchCatalog({ url: source.url, apiKey: API_KEY });
+    if (!first.changed) throw new Error("expected a changed first fetch");
+    const second = await fetchCatalog({ url: source.url, apiKey: API_KEY }, { etag: first.etag });
+    expect(second.changed).toBe(false);
+    expect(source.requests[1]?.ifNoneMatch).toBe(first.etag);
+  });
+
+  it("ignores unknown fields in the response body", async () => {
+    const body = JSON.stringify({
+      catalogVersion: "abc",
+      skills: [{ ...skill, extra: "noise" }],
+      futureField: 42,
+    });
+    const fetchImpl = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { etag: '"abc"' },
+      })) as typeof fetch;
+    const result = await fetchCatalog({ url: "http://x", apiKey: API_KEY }, { fetchImpl });
+    expect(result.changed).toBe(true);
+  });
+
+  it("falls back to the quoted catalogVersion when the ETag header is missing", async () => {
+    const body = JSON.stringify({ catalogVersion: "abc", skills: [] });
+    const fetchImpl = (async () => new Response(body, { status: 200 })) as typeof fetch;
+    const result = await fetchCatalog({ url: "http://x", apiKey: API_KEY }, { fetchImpl });
+    if (!result.changed) throw new Error("expected changed");
+    expect(result.etag).toBe('"abc"');
+  });
+
+  it("rejects a body without a string catalogVersion or a skills array", async () => {
+    for (const bad of [
+      JSON.stringify({ skills: [] }),
+      JSON.stringify({ catalogVersion: 7, skills: [] }),
+      JSON.stringify({ catalogVersion: "abc" }),
+      JSON.stringify({ catalogVersion: "abc", skills: "nope" }),
+      "not json",
+    ]) {
+      const fetchImpl = (async () => new Response(bad, { status: 200 })) as typeof fetch;
+      await expect(
+        fetchCatalog({ url: "http://x", apiKey: API_KEY }, { fetchImpl }),
+      ).rejects.toBeInstanceOf(CloudApiError);
+    }
+  });
+
+  it("maps 401 to CloudAuthError", async () => {
+    await expect(fetchCatalog({ url: source.url, apiKey: "wrong" })).rejects.toBeInstanceOf(
+      CloudAuthError,
+    );
+    await expect(fetchCatalog({ url: source.url })).rejects.toBeInstanceOf(CloudAuthError);
+  });
+
+  it("maps 503 to CloudUnavailableError", async () => {
+    source.failWith("catalog", { kind: "http", status: 503 });
+    await expect(fetchCatalog({ url: source.url, apiKey: API_KEY })).rejects.toBeInstanceOf(
+      CloudUnavailableError,
+    );
+  });
+
+  it("maps 404 to CloudApiError with status and code", async () => {
+    source.failWith("catalog", { kind: "http", status: 404 });
+    const err = await fetchCatalog({ url: source.url, apiKey: API_KEY }).catch((e) => e);
+    expect(err).toBeInstanceOf(CloudApiError);
+    expect(err.status).toBe(404);
+    expect(err.code).toBe("not_found");
+  });
+
+  it("maps a network failure to CloudUnavailableError", async () => {
+    source.failWith("catalog", { kind: "network" });
+    await expect(fetchCatalog({ url: source.url, apiKey: API_KEY })).rejects.toBeInstanceOf(
+      CloudUnavailableError,
+    );
+  });
+});

--- a/src/sdk/cloud/src/fetch-catalog.ts
+++ b/src/sdk/cloud/src/fetch-catalog.ts
@@ -1,0 +1,67 @@
+/**
+ * One conditional GET of a source's `/v1/catalog`. The single place the loader
+ * touches the network; everything above it consumes the discriminated
+ * changed/unchanged result.
+ */
+
+import type { CatalogSourceConfig } from "@ratel-ai/sdk";
+import type { CatalogSkillWire } from "./canonical.js";
+import { CloudApiError, CloudUnavailableError, errorFromResponse } from "./errors.js";
+
+/** The 200 body of `GET /v1/catalog` (`catalog-response.schema.json`). */
+export interface CatalogResponse {
+  catalogVersion: string;
+  skills: CatalogSkillWire[];
+}
+
+export type FetchCatalogResult =
+  | { changed: true; etag: string; catalog: CatalogResponse }
+  | { changed: false };
+
+export interface FetchCatalogOptions {
+  /** The cached ETag for this `(url, scope)`, sent as `If-None-Match`. */
+  etag?: string;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export async function fetchCatalog(
+  config: CatalogSourceConfig,
+  options: FetchCatalogOptions = {},
+): Promise<FetchCatalogResult> {
+  const url = new URL(`${config.url.replace(/\/+$/, "")}/v1/catalog`);
+  if (config.scope !== undefined) url.searchParams.set("scope", config.scope);
+
+  const headers: Record<string, string> = {};
+  if (config.apiKey !== undefined) headers.authorization = `Bearer ${config.apiKey}`;
+  if (options.etag !== undefined) headers["if-none-match"] = options.etag;
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchImpl(url.toString(), { headers });
+  } catch (err) {
+    throw new CloudUnavailableError(`catalog source unreachable: ${url.origin}`, { cause: err });
+  }
+
+  if (response.status === 304) return { changed: false };
+  if (!response.ok) {
+    throw errorFromResponse(response.status, await response.text().catch(() => ""));
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new CloudApiError("catalog source returned a non-JSON 200 body", response.status);
+  }
+  const catalog = body as CatalogResponse;
+  if (typeof catalog?.catalogVersion !== "string" || !Array.isArray(catalog?.skills)) {
+    throw new CloudApiError(
+      "catalog source returned an invalid catalog body (catalogVersion/skills)",
+      response.status,
+    );
+  }
+  const etag = response.headers.get("etag") ?? `"${catalog.catalogVersion}"`;
+  return { changed: true, etag, catalog };
+}

--- a/src/sdk/cloud/src/index.test.ts
+++ b/src/sdk/cloud/src/index.test.ts
@@ -1,0 +1,170 @@
+import { SkillCatalog } from "@ratel-ai/sdk";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { CatalogSkillWire } from "./canonical.js";
+import { etagOf } from "./canonical.js";
+import { CloudAuthError, CloudConfigError } from "./errors.js";
+import { createSkillSync, type SkillSyncHandle, syncSkills } from "./index.js";
+import { type MockSource, startMockSource } from "./testing/mock-source.js";
+
+const API_KEY = "test-key";
+
+const skill: CatalogSkillWire = {
+  id: "s1",
+  name: "alpha",
+  description: "First.",
+  tags: ["x"],
+  tools: [],
+  metadata: {},
+  body: "# A\n",
+};
+
+function respond200(skills: CatalogSkillWire[]): Response {
+  const { hex, etag } = etagOf(skills);
+  return new Response(JSON.stringify({ catalogVersion: hex, skills }), {
+    status: 200,
+    headers: { etag, "cache-control": "no-cache" },
+  });
+}
+
+function countingFetch(respond: () => Response) {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: RequestInfo | URL) => {
+    calls.push(String(url));
+    return respond();
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+let source: MockSource;
+let downUrl: string;
+
+beforeAll(async () => {
+  source = await startMockSource({ apiKey: API_KEY });
+  const down = await startMockSource();
+  downUrl = down.url;
+  await down.close();
+});
+
+afterAll(async () => {
+  await source.close();
+});
+
+const handles: SkillSyncHandle[] = [];
+afterEach(() => {
+  for (const handle of handles.splice(0)) handle.stop();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("createSkillSync", () => {
+  it("throws CloudConfigError immediately when no url is resolvable", () => {
+    expect(() => createSkillSync(new SkillCatalog(), { env: {} })).toThrow(CloudConfigError);
+  });
+
+  it("resolves RATEL_URL and RATEL_API_KEY from the injected env and hydrates", async () => {
+    source.setSkills([skill]);
+    const catalog = new SkillCatalog();
+    const handle = createSkillSync(catalog, {
+      env: { RATEL_URL: source.url, RATEL_API_KEY: API_KEY },
+    });
+    handles.push(handle);
+    await vi.waitFor(() => expect(catalog.size()).toBe(1));
+    expect(handle.ownedCount).toBe(1);
+    expect(handle.lastSyncedAt).toBeInstanceOf(Date);
+  });
+
+  it("prefers explicit options over env", async () => {
+    source.setSkills([skill]);
+    const catalog = new SkillCatalog();
+    const handle = createSkillSync(catalog, {
+      url: source.url,
+      apiKey: API_KEY,
+      env: { RATEL_URL: downUrl, RATEL_API_KEY: "wrong" },
+    });
+    handles.push(handle);
+    await vi.waitFor(() => expect(catalog.size()).toBe(1));
+  });
+
+  it("tolerates a failed first fetch — no throw, staleness surfaced on the handle", async () => {
+    const catalog = new SkillCatalog();
+    const handle = createSkillSync(catalog, { url: downUrl });
+    handles.push(handle);
+    await vi.waitFor(() => expect(handle.consecutiveFailures).toBeGreaterThan(0));
+    expect(catalog.size()).toBe(0);
+    expect(handle.lastSyncedAt).toBeUndefined();
+  });
+
+  it("starts the refresh chain at the configured interval", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { fetchImpl, calls } = countingFetch(() => respond200([skill]));
+    const handle = createSkillSync(new SkillCatalog(), {
+      url: "http://mock.invalid",
+      apiKey: API_KEY,
+      intervalMs: 1000,
+      fetchImpl,
+    });
+    handles.push(handle);
+    expect(calls).toHaveLength(1); // The immediate first refresh.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toHaveLength(2);
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("defaults the interval to five minutes", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { fetchImpl, calls } = countingFetch(() => respond200([skill]));
+    const handle = createSkillSync(new SkillCatalog(), {
+      url: "http://mock.invalid",
+      fetchImpl,
+    });
+    handles.push(handle);
+    expect(calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("syncSkills", () => {
+  it("throws CloudConfigError when no url is resolvable", async () => {
+    await expect(syncSkills(new SkillCatalog(), { env: {} })).rejects.toBeInstanceOf(
+      CloudConfigError,
+    );
+  });
+
+  it("one-shot syncs and returns the SyncResult", async () => {
+    source.setSkills([skill]);
+    const catalog = new SkillCatalog();
+    const result = await syncSkills(catalog, { url: source.url, apiKey: API_KEY });
+    expect(result).toMatchObject({ added: 1, updated: 0, removed: 0, unchanged: false });
+    expect(catalog.has("s1")).toBe(true);
+  });
+
+  it("throws on failure instead of tolerating it", async () => {
+    await expect(
+      syncSkills(new SkillCatalog(), { url: source.url, apiKey: "wrong" }),
+    ).rejects.toBeInstanceOf(CloudAuthError);
+  });
+
+  it("passes the scope through to the source", async () => {
+    source.setLayers({
+      global: [skill],
+      subjects: { alice: [{ ...skill, id: "a1", name: "alice-only" }] },
+    });
+    source.requests.length = 0;
+    const catalog = new SkillCatalog();
+    const result = await syncSkills(catalog, {
+      url: source.url,
+      apiKey: API_KEY,
+      scope: "alice",
+    });
+    expect(source.requests[0]?.scope).toBe("alice");
+    expect(result.added).toBe(2);
+    expect(catalog.has("a1")).toBe(true);
+  });
+});

--- a/src/sdk/cloud/src/index.ts
+++ b/src/sdk/cloud/src/index.ts
@@ -1,0 +1,95 @@
+/**
+ * `@ratel-ai/cloud` — pull-sync loader for a networked catalog source over the
+ * frozen protocol/v1 contract. `createSkillSync` attaches a source to a
+ * `SkillCatalog` and returns the running handle; `syncSkills` is the one-shot
+ * variant. Configuration resolves from explicit options over `RATEL_URL` /
+ * `RATEL_API_KEY` (ADR-0003).
+ */
+
+import { resolveSourceConfig, type SkillCatalog } from "@ratel-ai/sdk";
+import { CloudConfigError } from "./errors.js";
+import { SkillSync, type SkillSyncOptions, type SyncResult } from "./skill-sync.js";
+
+export type { CatalogSkillWire, SkillLike, SourceLayers } from "./canonical.js";
+export {
+  canonicalSet,
+  canonicalSkill,
+  etagOf,
+  projectSkill,
+  resolveScope,
+  skillsEqual,
+} from "./canonical.js";
+export {
+  CloudApiError,
+  CloudAuthError,
+  CloudConfigError,
+  CloudUnavailableError,
+} from "./errors.js";
+export type { CatalogResponse, FetchCatalogOptions, FetchCatalogResult } from "./fetch-catalog.js";
+export { fetchCatalog } from "./fetch-catalog.js";
+export type { SkillSyncOptions, SyncResult } from "./skill-sync.js";
+export { SkillSync } from "./skill-sync.js";
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface SyncSkillsOptions {
+  /** Base URL of the catalog source; falls back to `RATEL_URL`. */
+  url?: string;
+  /** Bearer key for every `/v1` request; falls back to `RATEL_API_KEY`. */
+  apiKey?: string;
+  /** Opaque subject selector, passed through as `?scope=`. Fixed per loader. */
+  scope?: string;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests; defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+export interface CreateSkillSyncOptions extends SyncSkillsOptions {
+  /** Refresh cadence of the periodic chain (default 5 minutes, ±10% jitter). */
+  intervalMs?: number;
+}
+
+/** The running loader returned by {@link createSkillSync}. */
+export type SkillSyncHandle = SkillSync;
+
+function requireConfig(options: SyncSkillsOptions) {
+  const config = resolveSourceConfig(options, options.env);
+  if (config === undefined) {
+    throw new CloudConfigError("no catalog source configured: pass `url` or set RATEL_URL");
+  }
+  return config;
+}
+
+function syncOptions(options: SyncSkillsOptions): SkillSyncOptions {
+  return options.fetchImpl ? { fetchImpl: options.fetchImpl } : {};
+}
+
+/**
+ * Attach a catalog source to `catalog` and return the running handle: an
+ * immediate first refresh plus the periodic chain. Offline-tolerant — a failed
+ * first fetch surfaces on the handle (`consecutiveFailures`, `lastSyncedAt`)
+ * instead of throwing; only an unresolvable configuration throws.
+ */
+export function createSkillSync(
+  catalog: SkillCatalog,
+  options: CreateSkillSyncOptions = {},
+): SkillSyncHandle {
+  const config = requireConfig(options);
+  const sync = new SkillSync(catalog, config, syncOptions(options));
+  sync.refresh().catch(() => {
+    // Surfaced via `consecutiveFailures`; the chain retries.
+  });
+  sync.start(options.intervalMs ?? DEFAULT_INTERVAL_MS);
+  return sync;
+}
+
+/** One-shot sync of `catalog` from the source. Throws on any failure. */
+export async function syncSkills(
+  catalog: SkillCatalog,
+  options: SyncSkillsOptions = {},
+): Promise<SyncResult> {
+  const config = requireConfig(options);
+  const sync = new SkillSync(catalog, config, syncOptions(options));
+  return sync.refresh();
+}

--- a/src/sdk/cloud/src/integration.test.ts
+++ b/src/sdk/cloud/src/integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * End to end over real parts: a `SkillCatalog` hydrated from the mock source
+ * through `createSkillSync`, retrieved through the capability tools.
+ */
+
+import {
+  type SearchCapabilitiesResult,
+  SkillCatalog,
+  searchCapabilitiesTool,
+  ToolCatalog,
+} from "@ratel-ai/sdk";
+import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
+import type { CatalogSkillWire } from "./canonical.js";
+import { createSkillSync, type SkillSyncHandle } from "./index.js";
+import { type MockSource, startMockSource } from "./testing/mock-source.js";
+
+const API_KEY = "test-key";
+
+const deploySkill: CatalogSkillWire = {
+  id: "deploy-service",
+  name: "deploy-service",
+  description: "Deploy a service to production with health checks and rollback.",
+  tags: ["deploy", "release"],
+  tools: [],
+  metadata: {},
+  body: "# Deploy\n1. Build\n2. Ship\n",
+};
+
+const auditSkill: CatalogSkillWire = {
+  id: "audit-logs",
+  name: "audit-logs",
+  description: "Collect and summarize audit logs for a time range.",
+  tags: ["logs"],
+  tools: [],
+  metadata: {},
+  body: "# Audit\n",
+};
+
+let source: MockSource;
+let handle: SkillSyncHandle;
+
+beforeAll(async () => {
+  source = await startMockSource({ apiKey: API_KEY });
+});
+
+afterAll(async () => {
+  await source.close();
+});
+
+afterEach(() => {
+  handle?.stop();
+});
+
+it("flips the live capability-tool description once the sync hydrates skills", async () => {
+  source.setSkills([deploySkill]);
+  const skillCatalog = new SkillCatalog();
+  const capabilityTool = searchCapabilitiesTool(new ToolCatalog(), skillCatalog);
+  expect(capabilityTool.description).not.toContain("get_skill_content");
+
+  handle = createSkillSync(skillCatalog, { url: source.url, apiKey: API_KEY });
+  await handle.refresh();
+  expect(capabilityTool.description).toContain("get_skill_content");
+});
+
+it("hydrates, retrieves, removes, and preserves host skills end to end", async () => {
+  source.setSkills([deploySkill, auditSkill]);
+  const skillCatalog = new SkillCatalog();
+  skillCatalog.register({
+    id: "audit-logs",
+    name: "host-audit",
+    description: "Host-registered audit skill.",
+    body: "host body",
+  });
+  const capabilityTool = searchCapabilitiesTool(new ToolCatalog(), skillCatalog);
+
+  // Before hydration only the host skill exists; after the first refresh the
+  // live description advertises the skills bucket.
+  expect(skillCatalog.size()).toBe(1);
+  handle = createSkillSync(skillCatalog, { url: source.url, apiKey: API_KEY });
+  const first = await handle.refresh();
+  expect(skillCatalog.size()).toBe(2);
+  expect(handle.ownedCount).toBe(1);
+  expect(capabilityTool.description).toContain("get_skill_content");
+
+  // The host-registered skill with the colliding id survived untouched.
+  expect(first.conflicts).toEqual(["audit-logs"]);
+  expect(skillCatalog.get("audit-logs")?.name).toBe("host-audit");
+
+  // The capability-tools search over the catalog finds the synced skill.
+  const hit = (await capabilityTool.execute({
+    query: "deploy a service to production",
+  })) as SearchCapabilitiesResult;
+  expect(hit.skills.map((s) => s.skillId)).toContain("deploy-service");
+
+  // A skill removed on the source disappears after the next refresh.
+  source.setSkills([auditSkill]);
+  const second = await handle.refresh();
+  expect(second.removed).toBe(1);
+  expect(skillCatalog.has("deploy-service")).toBe(false);
+  const gone = (await capabilityTool.execute({
+    query: "deploy a service to production",
+  })) as SearchCapabilitiesResult;
+  expect(gone.skills.map((s) => s.skillId)).not.toContain("deploy-service");
+  expect(skillCatalog.get("audit-logs")?.name).toBe("host-audit");
+});

--- a/src/sdk/cloud/src/skill-sync.test.ts
+++ b/src/sdk/cloud/src/skill-sync.test.ts
@@ -1,0 +1,281 @@
+import { SkillCatalog } from "@ratel-ai/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CatalogSkillWire } from "./canonical.js";
+import { etagOf } from "./canonical.js";
+import { SkillSync, type SyncResult } from "./skill-sync.js";
+
+const wire = (id: string, over: Partial<CatalogSkillWire> = {}): CatalogSkillWire => ({
+  id,
+  name: `${id}-name`,
+  description: `${id} description`,
+  tags: ["t"],
+  tools: [],
+  metadata: {},
+  body: `# ${id}\n`,
+  ...over,
+});
+
+function respond200(skills: CatalogSkillWire[]): Response {
+  const { hex, etag } = etagOf(skills);
+  return new Response(JSON.stringify({ catalogVersion: hex, skills }), {
+    status: 200,
+    headers: { etag, "cache-control": "no-cache" },
+  });
+}
+
+function respondError(status: number, code: string): Response {
+  return new Response(JSON.stringify({ error: { code, message: "boom" } }), { status });
+}
+
+/** A scripted fetch stub: shifts through `script`, repeating the last entry. */
+function scriptedFetch(script: (() => Response | Error)[]) {
+  const calls: { ifNoneMatch: string | null }[] = [];
+  const fetchImpl = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ ifNoneMatch: headers["if-none-match"] ?? null });
+    const step = script.length > 1 ? script.shift() : script[0];
+    if (!step) throw new Error("scripted fetch exhausted");
+    const out = step();
+    if (out instanceof Error) throw out;
+    return out;
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const config = { url: "http://mock.invalid", apiKey: "k" };
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SkillSync.refresh", () => {
+  it("hydrates the catalog and projects wire skills to the 7 fields", async () => {
+    const catalog = new SkillCatalog();
+    const noisy = { ...wire("a"), extra: "noise" } as CatalogSkillWire;
+    const { fetchImpl } = scriptedFetch([() => respond200([noisy, wire("b")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    const result = await sync.refresh();
+    expect(result).toEqual<SyncResult>({
+      added: 2,
+      updated: 0,
+      removed: 0,
+      conflicts: [],
+      unchanged: false,
+    });
+    expect(catalog.size()).toBe(2);
+    expect(catalog.get("a")).not.toHaveProperty("extra");
+    expect(sync.ownedCount).toBe(2);
+    expect(sync.lastSyncedAt).toBeInstanceOf(Date);
+    expect(sync.consecutiveFailures).toBe(0);
+  });
+
+  it("coalesces concurrent refresh calls on the in-flight promise", async () => {
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([() => respond200([wire("a")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    const [r1, r2] = await Promise.all([sync.refresh(), sync.refresh()]);
+    expect(r1).toBe(r2);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("emits zero churn on a full resync of identical data", async () => {
+    const catalog = new SkillCatalog();
+    const { fetchImpl } = scriptedFetch([() => respond200([wire("a"), wire("b")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+    await sync.refresh();
+
+    const spy = vi.fn();
+    catalog.onChange(spy);
+    const result = await sync.refresh();
+    expect(spy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ added: 0, updated: 0, removed: 0, conflicts: [] });
+  });
+
+  it("upserts only the skill whose 7-field projection changed", async () => {
+    const catalog = new SkillCatalog();
+    const { fetchImpl } = scriptedFetch([
+      () => respond200([wire("a"), wire("b")]),
+      () => respond200([wire("a", { body: "changed\n" }), wire("b")]),
+    ]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+    await sync.refresh();
+
+    const result = await sync.refresh();
+    expect(result).toMatchObject({ added: 0, updated: 1, removed: 0 });
+    expect(catalog.get("a")?.body).toBe("changed\n");
+  });
+
+  it("removes and disowns an owned id that left the wire", async () => {
+    const catalog = new SkillCatalog();
+    const { fetchImpl } = scriptedFetch([
+      () => respond200([wire("a"), wire("b")]),
+      () => respond200([wire("b")]),
+    ]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+    await sync.refresh();
+
+    const result = await sync.refresh();
+    expect(result).toMatchObject({ added: 0, updated: 0, removed: 1 });
+    expect(catalog.has("a")).toBe(false);
+    expect(sync.ownedCount).toBe(1);
+  });
+
+  it("never touches a host-registered skill with a colliding id — records a conflict", async () => {
+    const catalog = new SkillCatalog();
+    catalog.register({ id: "a", name: "host-owned", description: "host", body: "host body" });
+    const { fetchImpl } = scriptedFetch([() => respond200([wire("a"), wire("b")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    const result = await sync.refresh();
+    expect(result).toMatchObject({ added: 1, conflicts: ["a"] });
+    expect(catalog.get("a")?.name).toBe("host-owned");
+    expect(sync.ownedCount).toBe(1);
+
+    // The conflicting id is never disowned into a removal either.
+    const again = await sync.refresh();
+    expect(again.conflicts).toEqual(["a"]);
+    expect(catalog.get("a")?.name).toBe("host-owned");
+  });
+
+  it("treats a 304 as a revalidated no-op that still refreshes lastSyncedAt", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([
+      () => respond200([wire("a")]),
+      () => new Response(null, { status: 304 }),
+    ]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+    await sync.refresh();
+    const first = sync.lastSyncedAt;
+
+    vi.setSystemTime(2_000_000);
+    const result = await sync.refresh();
+    expect(result).toEqual<SyncResult>({
+      added: 0,
+      updated: 0,
+      removed: 0,
+      conflicts: [],
+      unchanged: true,
+    });
+    expect(calls[1]?.ifNoneMatch).toBe(etagOf([wire("a")]).etag);
+    expect(sync.lastSyncedAt?.getTime()).toBeGreaterThan(first?.getTime() ?? Infinity);
+    expect(catalog.has("a")).toBe(true);
+  });
+
+  it("keeps the replica and counts consecutive failures on transient errors", async () => {
+    const catalog = new SkillCatalog();
+    const { fetchImpl } = scriptedFetch([
+      () => respond200([wire("a")]),
+      () => respondError(503, "unavailable"),
+      () => new TypeError("fetch failed"),
+      () => respond200([wire("a")]),
+    ]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+    await sync.refresh();
+
+    await expect(sync.refresh()).rejects.toThrow();
+    expect(sync.consecutiveFailures).toBe(1);
+    await expect(sync.refresh()).rejects.toThrow();
+    expect(sync.consecutiveFailures).toBe(2);
+    expect(catalog.has("a")).toBe(true);
+
+    await sync.refresh();
+    expect(sync.consecutiveFailures).toBe(0);
+  });
+});
+
+describe("SkillSync.start/stop", () => {
+  it("schedules a setTimeout chain with ±10% jitter", async () => {
+    vi.useFakeTimers();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0); // low edge: 0.9 × interval
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([() => respond200([wire("a")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    sync.start(1000);
+    await vi.advanceTimersByTimeAsync(899);
+    expect(calls).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toHaveLength(1);
+
+    random.mockReturnValue(1); // high edge: 1.1 × interval
+    await vi.advanceTimersByTimeAsync(1099);
+    expect(calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toHaveLength(2);
+    sync.stop();
+  });
+
+  it("keeps the chain alive across transient failures", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([() => respondError(503, "unavailable")]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    sync.start(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toHaveLength(3);
+    expect(sync.consecutiveFailures).toBe(3);
+    expect(sync.stopped).toBe(false);
+    sync.stop();
+  });
+
+  it("stops the chain permanently on an auth error and surfaces the stopped state", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([() => respondError(401, "unauthorized")]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    sync.start(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toHaveLength(1);
+    expect(sync.stopped).toBe(true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("stop() is idempotent and cancels the pending timer", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const catalog = new SkillCatalog();
+    const { fetchImpl, calls } = scriptedFetch([() => respond200([wire("a")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    sync.start(1000);
+    sync.stop();
+    sync.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("unrefs the timer so the chain never holds the process open", () => {
+    const unref = vi.fn();
+    const cleared: unknown[] = [];
+    const handle = { unref };
+    vi.stubGlobal(
+      "setTimeout",
+      vi.fn(() => handle),
+    );
+    vi.stubGlobal(
+      "clearTimeout",
+      vi.fn((t: unknown) => cleared.push(t)),
+    );
+    const catalog = new SkillCatalog();
+    const { fetchImpl } = scriptedFetch([() => respond200([wire("a")])]);
+    const sync = new SkillSync(catalog, config, { fetchImpl });
+
+    sync.start(1000);
+    expect(unref).toHaveBeenCalledTimes(1);
+    sync.stop();
+    expect(cleared).toEqual([handle]);
+  });
+});

--- a/src/sdk/cloud/src/skill-sync.ts
+++ b/src/sdk/cloud/src/skill-sync.ts
@@ -1,0 +1,200 @@
+/**
+ * Pull-sync of a catalog source into a local `SkillCatalog`. One conditional
+ * fetch per refresh; the wire diff is applied under the ownership rule: the
+ * sync only ever mutates skills it created, host-registered skills are never
+ * touched and surface in `SyncResult.conflicts`.
+ */
+
+import type { CatalogSourceConfig, SkillCatalog } from "@ratel-ai/sdk";
+import { type CatalogSkillWire, projectSkill, skillsEqual } from "./canonical.js";
+import { CloudAuthError } from "./errors.js";
+import { fetchCatalog } from "./fetch-catalog.js";
+
+export interface SyncResult {
+  added: number;
+  updated: number;
+  removed: number;
+  /** Wire ids that collided with host-registered skills and were left untouched. */
+  conflicts: string[];
+  /** True when the source answered 304 — the replica was revalidated as-is. */
+  unchanged: boolean;
+}
+
+export interface SkillSyncOptions {
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+// The chain fires at interval ±10% so a fleet of loaders never thunders in step.
+const JITTER = 0.1;
+
+export class SkillSync {
+  private readonly catalog: SkillCatalog;
+  private readonly config: CatalogSourceConfig;
+  private readonly fetchImpl?: typeof fetch;
+
+  /** Cached ETag for this loader's fixed `(url, scope)`. */
+  private etag?: string;
+  private readonly ownedIds = new Set<string>();
+  private inFlight?: Promise<SyncResult>;
+  private timer?: ReturnType<typeof setTimeout>;
+  private intervalMs?: number;
+  private authStopped = false;
+
+  private syncedAt?: Date;
+  private failures = 0;
+
+  constructor(catalog: SkillCatalog, config: CatalogSourceConfig, options: SkillSyncOptions = {}) {
+    this.catalog = catalog;
+    this.config = config;
+    if (options.fetchImpl !== undefined) this.fetchImpl = options.fetchImpl;
+  }
+
+  get lastSyncedAt(): Date | undefined {
+    return this.syncedAt;
+  }
+
+  get consecutiveFailures(): number {
+    return this.failures;
+  }
+
+  get ownedCount(): number {
+    return this.ownedIds.size;
+  }
+
+  /** True once the chain has been shut down — permanently so after an auth error. */
+  get stopped(): boolean {
+    return this.authStopped;
+  }
+
+  /** One conditional fetch + diff apply. Concurrent calls coalesce on the in-flight promise. */
+  refresh(): Promise<SyncResult> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.doRefresh().finally(() => {
+      this.inFlight = undefined;
+    });
+    return this.inFlight;
+  }
+
+  private async doRefresh(): Promise<SyncResult> {
+    let fetched: Awaited<ReturnType<typeof fetchCatalog>>;
+    try {
+      const options = this.fetchImpl
+        ? { etag: this.etag, fetchImpl: this.fetchImpl }
+        : { etag: this.etag };
+      fetched = await fetchCatalog(this.config, options);
+    } catch (err) {
+      this.failures += 1;
+      throw err;
+    }
+
+    this.failures = 0;
+    this.syncedAt = new Date();
+    if (!fetched.changed) {
+      return { added: 0, updated: 0, removed: 0, conflicts: [], unchanged: true };
+    }
+
+    const result = this.applyDiff(fetched.catalog.skills);
+    this.etag = fetched.etag;
+    return result;
+  }
+
+  private applyDiff(wireSkills: CatalogSkillWire[]): SyncResult {
+    const result: SyncResult = {
+      added: 0,
+      updated: 0,
+      removed: 0,
+      conflicts: [],
+      unchanged: false,
+    };
+    const wireIds = new Set<string>();
+
+    for (const raw of wireSkills) {
+      const skill = projectSkill(raw);
+      wireIds.add(skill.id);
+      if (this.ownedIds.has(skill.id)) {
+        const current = this.catalog.get(skill.id);
+        if (current === undefined || !skillsEqual(current, skill)) {
+          this.catalog.upsert(skill);
+          result.updated += 1;
+        }
+      } else if (this.catalog.has(skill.id)) {
+        result.conflicts.push(skill.id);
+      } else {
+        this.catalog.upsert(skill);
+        this.ownedIds.add(skill.id);
+        result.added += 1;
+      }
+    }
+
+    for (const id of [...this.ownedIds]) {
+      if (!wireIds.has(id)) {
+        this.catalog.remove(id);
+        this.ownedIds.delete(id);
+        result.removed += 1;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Start the periodic refresh chain: a `setTimeout` chain (never
+   * `setInterval`) at `intervalMs` ±10% jitter, `unref()`ed so it can't hold
+   * the process open. Transient failures keep the chain alive; an auth error
+   * stops it permanently.
+   */
+  start(intervalMs: number): void {
+    if (this.timer !== undefined || this.authStopped) return;
+    this.intervalMs = intervalMs;
+    this.scheduleTick();
+  }
+
+  /** Cancel the pending tick. Idempotent. */
+  stop(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.intervalMs = undefined;
+  }
+
+  // The tick waits the guaranteed minimum (interval − 10%) first and samples
+  // the jitter extra (up to +20% of that point) only when the minimum
+  // elapses, so each fire draws fresh randomness.
+  private scheduleTick(): void {
+    const interval = this.intervalMs;
+    if (interval === undefined) return;
+    this.setTimer(interval * (1 - JITTER), () => {
+      const extra = interval * 2 * JITTER * Math.random();
+      // Timers clamp sub-1ms delays to 1ms; a zero extra fires in-tick instead.
+      if (extra < 1) {
+        void this.tick();
+      } else {
+        this.setTimer(extra, () => void this.tick());
+      }
+    });
+  }
+
+  private setTimer(delay: number, onFire: () => void): void {
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      onFire();
+    }, delay);
+    this.timer.unref?.();
+  }
+
+  private async tick(): Promise<void> {
+    try {
+      await this.refresh();
+    } catch (err) {
+      if (err instanceof CloudAuthError) {
+        this.authStopped = true;
+        this.stop();
+        return;
+      }
+      // Transient (network / 5xx / unexpected): replica stays live, chain continues.
+    }
+    this.scheduleTick();
+  }
+}

--- a/src/sdk/cloud/src/testing/mock-source.test.ts
+++ b/src/sdk/cloud/src/testing/mock-source.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SourceLayers } from "../canonical.js";
+import { type MockSource, startMockSource } from "./mock-source.js";
+
+const VECTORS_URL = new URL("../../../../../protocol/v1/conformance/vectors.json", import.meta.url);
+
+interface EtagVector {
+  name: string;
+  catalog: string;
+  scope: string | null;
+  expect: { resolvedIds: string[]; etag: string };
+}
+
+interface InmVector {
+  name: string;
+  current: string;
+  of?: string;
+  ifNoneMatch: { kind: string };
+  expect: 200 | 304;
+}
+
+interface VectorsDoc {
+  catalogs: Record<string, SourceLayers>;
+  etag: EtagVector[];
+  equalEtags: string[][];
+  distinctEtags: string[][];
+  inm: InmVector[];
+  wire: { skillFields: string[]; forbiddenFieldSubstrings: string[] };
+}
+
+const doc: VectorsDoc = JSON.parse(readFileSync(VECTORS_URL, "utf8"));
+const API_KEY = "test-key";
+
+let source: MockSource;
+
+beforeAll(async () => {
+  source = await startMockSource({ apiKey: API_KEY });
+});
+
+afterAll(async () => {
+  await source.close();
+});
+
+function catalogUrl(scope: string | null): string {
+  const url = new URL("/v1/catalog", source.url);
+  if (scope !== null) url.searchParams.set("scope", scope);
+  return url.toString();
+}
+
+async function get(
+  scope: string | null,
+  headers: Record<string, string> = { authorization: `Bearer ${API_KEY}` },
+): Promise<Response> {
+  return fetch(catalogUrl(scope), { headers });
+}
+
+describe("auth", () => {
+  it("rejects a missing or wrong Bearer key with the frozen 401 body", async () => {
+    source.setSkills([]);
+    for (const headers of [{}, { authorization: "Bearer wrong" }, { authorization: "Basic x" }]) {
+      const res = await get(null, headers);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.code).toBe("unauthorized");
+      expect(typeof body.error.message).toBe("string");
+    }
+  });
+
+  it("serves /healthz unauthenticated", async () => {
+    const res = await fetch(new URL("/healthz", source.url));
+    expect(res.status).toBe(200);
+  });
+
+  it("answers an unknown /v1 path with the frozen 404 body", async () => {
+    const res = await fetch(new URL("/v1/nope", source.url), {
+      headers: { authorization: `Bearer ${API_KEY}` },
+    });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("not_found");
+  });
+});
+
+describe("etag vectors over real HTTP", () => {
+  const byName = new Map<string, string>();
+
+  it.each(
+    doc.etag.map((v) => [v.name, v] as const),
+  )("vector %s: resolved ids, ETag header, bare catalogVersion", async (_name, v) => {
+    source.setLayers(doc.catalogs[v.catalog]);
+    const res = await get(v.scope);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe(v.expect.etag);
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    const body = await res.json();
+    expect(`"${body.catalogVersion}"`).toBe(v.expect.etag);
+    expect(body.skills.map((s: { id: string }) => s.id)).toEqual(v.expect.resolvedIds);
+    byName.set(v.name, v.expect.etag);
+  });
+
+  it.each(
+    doc.equalEtags.map((g) => [g.join("+"), g] as const),
+  )("equalEtags group %s", (_label, group) => {
+    const tags = group.map((n) => byName.get(n));
+    expect(tags.every((t) => t !== undefined)).toBe(true);
+    expect(new Set(tags).size).toBe(1);
+  });
+
+  it.each(
+    doc.distinctEtags.map((g) => [g.join("+"), g] as const),
+  )("distinctEtags group %s", (_label, group) => {
+    const tags = group.map((n) => byName.get(n));
+    expect(tags.every((t) => t !== undefined)).toBe(true);
+    expect(new Set(tags).size).toBe(group.length);
+  });
+});
+
+describe("if-none-match vectors over real HTTP", () => {
+  function etagVector(name: string): EtagVector {
+    const v = doc.etag.find((e) => e.name === name);
+    if (!v) throw new Error(`unknown etag vector: ${name}`);
+    return v;
+  }
+
+  function buildHeader(kind: string, current: string, other?: string): string | null {
+    switch (kind) {
+      case "self":
+        return current;
+      case "weakSelf":
+        return `W/${current}`;
+      case "star":
+        return "*";
+      case "listWithSelf":
+        return `"deadbeef", ${current}`;
+      case "listMiss":
+        return '"deadbeef", "c0ffeec0ffeec0ffee"';
+      case "absent":
+        return null;
+      case "other":
+        if (!other) throw new Error("kind=other needs an `of` vector");
+        return other;
+      default:
+        throw new Error(`unknown If-None-Match kind: ${kind}`);
+    }
+  }
+
+  it.each(doc.inm.map((v) => [v.name, v] as const))("inm vector %s", async (_name, v) => {
+    const current = etagVector(v.current);
+    const other = v.of ? etagVector(v.of) : undefined;
+    source.setLayers(doc.catalogs[current.catalog]);
+    const header = buildHeader(v.ifNoneMatch.kind, current.expect.etag, other?.expect.etag);
+    const headers: Record<string, string> = { authorization: `Bearer ${API_KEY}` };
+    if (header !== null) headers["if-none-match"] = header;
+    const res = await get(current.scope, headers);
+    expect(res.status).toBe(v.expect);
+    if (v.expect === 304) {
+      expect(await res.text()).toBe("");
+    }
+  });
+
+  it("covers all committed inm vectors", () => {
+    expect(doc.inm.length).toBe(7);
+  });
+});
+
+describe("secrets never on the wire (structural)", () => {
+  function forbiddenKeys(value: unknown, path = ""): string[] {
+    if (Array.isArray(value)) return value.flatMap((v, i) => forbiddenKeys(v, `${path}[${i}]`));
+    if (value === null || typeof value !== "object") return [];
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, v]) => {
+      const hit = doc.wire.forbiddenFieldSubstrings.some((sub) => key.toLowerCase().includes(sub));
+      const here = hit ? [`${path}.${key}`] : [];
+      return [...here, ...forbiddenKeys(v, `${path}.${key}`)];
+    });
+  }
+
+  it("serves exactly the wire skillFields and no forbidden field name, for every fixture and scope", async () => {
+    for (const [name, layers] of Object.entries(doc.catalogs)) {
+      const scopes: (string | null)[] = [null, ...Object.keys(layers.subjects ?? {})];
+      for (const scope of scopes) {
+        source.setLayers(layers);
+        const res = await get(scope);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(forbiddenKeys(body), `catalog ${name} scope ${scope}`).toEqual([]);
+        for (const skill of body.skills) {
+          expect(Object.keys(skill).sort()).toEqual([...doc.wire.skillFields].sort());
+        }
+      }
+    }
+  });
+});
+
+describe("request recording and failure injection", () => {
+  it("records method, path, scope, if-none-match, and authorization", async () => {
+    source.setSkills([]);
+    source.requests.length = 0;
+    await get("alice", { authorization: `Bearer ${API_KEY}`, "if-none-match": '"abc"' });
+    expect(source.requests).toHaveLength(1);
+    expect(source.requests[0]).toMatchObject({
+      method: "GET",
+      path: "/v1/catalog",
+      scope: "alice",
+      ifNoneMatch: '"abc"',
+      authorization: `Bearer ${API_KEY}`,
+    });
+  });
+
+  it("injects an HTTP failure on the catalog endpoint until cleared", async () => {
+    source.failWith("catalog", { kind: "http", status: 503 });
+    const res = await get(null);
+    expect(res.status).toBe(503);
+    expect((await res.json()).error.code).toBe("unavailable");
+    source.failWith("catalog", undefined);
+    expect((await get(null)).status).toBe(200);
+  });
+
+  it("injects a network failure (socket destroyed)", async () => {
+    source.failWith("catalog", { kind: "network" });
+    await expect(get(null)).rejects.toThrow();
+    source.failWith("catalog", undefined);
+    expect((await get(null)).status).toBe(200);
+  });
+
+  it("injects failures on healthz independently", async () => {
+    source.failWith("healthz", { kind: "http", status: 503 });
+    expect((await fetch(new URL("/healthz", source.url))).status).toBe(503);
+    source.failWith("healthz", undefined);
+    expect((await fetch(new URL("/healthz", source.url))).status).toBe(200);
+  });
+});

--- a/src/sdk/cloud/src/testing/mock-source.ts
+++ b/src/sdk/cloud/src/testing/mock-source.ts
@@ -1,0 +1,182 @@
+/**
+ * In-process catalog source for tests: the source side of the frozen
+ * protocol/v1 contract on a `node:http` server bound to port 0. Serves the
+ * real ETag algorithm and scope overlay from `../canonical.js`, weak
+ * `If-None-Match` matching, frozen error bodies, Bearer auth, request
+ * recording, and per-endpoint failure injection. Pinned against
+ * `protocol/v1/conformance/vectors.json` in its own test.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  type CatalogSkillWire,
+  etagOf,
+  projectSkill,
+  resolveScope,
+  type SourceLayers,
+} from "../canonical.js";
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  scope: string | null;
+  ifNoneMatch: string | null;
+  authorization: string | null;
+}
+
+export type InjectedFailure =
+  | { kind: "http"; status: number; code?: string; message?: string }
+  | { kind: "network" };
+
+export type MockEndpoint = "catalog" | "healthz";
+
+export interface MockSourceOptions {
+  /** Bearer key the source accepts (default `"test-key"`). */
+  apiKey?: string;
+}
+
+/**
+ * Weak `If-None-Match` comparison (RFC 7232 §3.2): tolerates a `W/` prefix,
+ * surrounding quotes, comma lists, and `*`. v1 ETags are comma-free hex, so a
+ * plain split is sufficient.
+ */
+export function ifNoneMatchMatches(headerValue: string | null, currentEtag: string): boolean {
+  if (headerValue == null) return false;
+  const opaque = (tag: string): string => {
+    let t = tag.trim();
+    if (t.startsWith("W/")) t = t.slice(2).trim();
+    if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) t = t.slice(1, -1);
+    return t;
+  };
+  const v = headerValue.trim();
+  if (v === "*") return true;
+  const current = opaque(currentEtag);
+  return v.split(",").some((tok) => {
+    const o = opaque(tok);
+    return o.length > 0 && o === current;
+  });
+}
+
+const CODE_BY_STATUS: Record<number, string> = {
+  400: "invalid_request",
+  401: "unauthorized",
+  404: "not_found",
+  503: "unavailable",
+};
+
+export class MockSource {
+  readonly url: string;
+  readonly apiKey: string;
+  readonly requests: RecordedRequest[] = [];
+
+  private layers: SourceLayers = { global: [] };
+  private readonly failures = new Map<MockEndpoint, InjectedFailure>();
+  private readonly server: Server;
+
+  constructor(server: Server, url: string, apiKey: string) {
+    this.server = server;
+    this.url = url;
+    this.apiKey = apiKey;
+  }
+
+  /** Replace the source's layers with a global-only set. */
+  setSkills(skills: CatalogSkillWire[]): void {
+    this.layers = { global: skills };
+  }
+
+  /** Replace the source's full layer set (global + per-subject overlays). */
+  setLayers(layers: SourceLayers): void {
+    this.layers = layers;
+  }
+
+  /** Inject a persistent failure on one endpoint; pass `undefined` to clear it. */
+  failWith(endpoint: MockEndpoint, failure: InjectedFailure | undefined): void {
+    if (failure === undefined) this.failures.delete(endpoint);
+    else this.failures.set(endpoint, failure);
+  }
+
+  close(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  /** @internal request handler wired up by {@link startMockSource}. */
+  handle(req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse): void {
+    const url = new URL(req.url ?? "/", this.url);
+    this.requests.push({
+      method: req.method ?? "",
+      path: url.pathname,
+      scope: url.searchParams.get("scope"),
+      ifNoneMatch: req.headers["if-none-match"] ?? null,
+      authorization: req.headers.authorization ?? null,
+    });
+
+    if (url.pathname === "/healthz") {
+      if (this.injectFailure("healthz", res)) return;
+      res.writeHead(200).end();
+      return;
+    }
+
+    if (url.pathname === "/v1/catalog" && req.method === "GET") {
+      if (this.injectFailure("catalog", res)) return;
+      if (req.headers.authorization !== `Bearer ${this.apiKey}`) {
+        this.error(res, 401);
+        return;
+      }
+      const resolved = resolveScope(this.layers, url.searchParams.get("scope")).map(projectSkill);
+      const { hex, etag } = etagOf(resolved);
+      if (ifNoneMatchMatches(req.headers["if-none-match"] ?? null, etag)) {
+        res.writeHead(304, { etag }).end();
+        return;
+      }
+      res
+        .writeHead(200, {
+          "content-type": "application/json",
+          "cache-control": "no-cache",
+          etag,
+        })
+        .end(JSON.stringify({ catalogVersion: hex, skills: resolved }));
+      return;
+    }
+
+    this.error(res, 404);
+  }
+
+  private injectFailure(endpoint: MockEndpoint, res: import("node:http").ServerResponse): boolean {
+    const failure = this.failures.get(endpoint);
+    if (!failure) return false;
+    if (failure.kind === "network") {
+      res.destroy();
+      return true;
+    }
+    this.error(res, failure.status, failure.code, failure.message);
+    return true;
+  }
+
+  private error(
+    res: import("node:http").ServerResponse,
+    status: number,
+    code = CODE_BY_STATUS[status] ?? "invalid_request",
+    message = `mock source: ${status}`,
+  ): void {
+    res
+      .writeHead(status, { "content-type": "application/json" })
+      .end(JSON.stringify({ error: { code, message } }));
+  }
+}
+
+/** Start a mock source on an ephemeral loopback port. */
+export function startMockSource(options: MockSourceOptions = {}): Promise<MockSource> {
+  return new Promise((resolve, reject) => {
+    let source: MockSource;
+    const server = createServer((req, res) => source.handle(req, res));
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      source = new MockSource(server, `http://127.0.0.1:${port}`, options.apiKey ?? "test-key");
+      resolve(source);
+    });
+  });
+}

--- a/src/sdk/cloud/tsconfig.json
+++ b/src/sdk/cloud/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/src/sdk/python/native/src/lib.rs
+++ b/src/sdk/python/native/src/lib.rs
@@ -267,6 +267,36 @@ impl SkillRegistry {
         });
     }
 
+    /// See [`ratel_ai_core::SkillRegistry::remove`]: drop every skill with this
+    /// id; `True` when anything was removed.
+    fn remove(&mut self, skill_id: String) -> bool {
+        self.inner.remove(&skill_id)
+    }
+
+    /// See [`ratel_ai_core::SkillRegistry::upsert`]: register-or-replace by id;
+    /// `True` when an existing skill was replaced.
+    #[allow(clippy::too_many_arguments)]
+    fn upsert(
+        &mut self,
+        id: String,
+        name: String,
+        description: String,
+        tags: Vec<String>,
+        tools: Vec<String>,
+        metadata: HashMap<String, Vec<String>>,
+        body: String,
+    ) -> bool {
+        self.inner.upsert(core::Skill {
+            id,
+            name,
+            description,
+            tags,
+            tools,
+            metadata,
+            body,
+        })
+    }
+
     fn search(&self, query: String, top_k: u32) -> Vec<SkillHit> {
         self.inner
             .search(&query, top_k as usize)

--- a/src/sdk/python/ratel_ai/__init__.py
+++ b/src/sdk/python/ratel_ai/__init__.py
@@ -8,6 +8,9 @@ Mirrors the public surface of the TypeScript SDK (`@ratel-ai/sdk`):
 - `search_capabilities_tool` / `invoke_tool_tool` / `get_skill_content_tool` —
   framework-neutral capability tools.
 - `register_mcp_server` — ingest an upstream MCP server's tools (extra: mcp).
+- `resolve_source_config` / `SourceConfig` / `SourceOptions` — pure resolution of
+  the catalog-source seam (`RATEL_URL` / `RATEL_API_KEY`); loaders live in
+  `ratel-ai-cloud`.
 """
 
 from ._native import SearchHit, SkillHit, SkillRegistry, ToolRegistry
@@ -36,6 +39,7 @@ from .compat import SEARCH_TOOLS_ID, search_tools_tool
 from .mcp import McpServerHandle, register_mcp_server
 from .skill_catalog import Skill, SkillCatalog
 from .skill_tools import GET_SKILL_CONTENT_ID, get_skill_content_tool
+from .source import SourceConfig, SourceOptions, resolve_source_config
 
 # OpenTelemetry export of the ratel.*/gen_ai.* funnel (ADR-0007). The SDK always
 # emits spans to the active OTel provider (a no-op until one is wired);
@@ -59,6 +63,8 @@ __all__ = [
     "SkillCatalog",
     "SkillHit",
     "SkillRegistry",
+    "SourceConfig",
+    "SourceOptions",
     "Tool",
     "ToolCatalog",
     "ToolRegistry",
@@ -69,6 +75,7 @@ __all__ = [
     "get_skill_content_tool",
     "invoke_tool_tool",
     "register_mcp_server",
+    "resolve_source_config",
     "search_capabilities_tool",
     "search_tools_tool",
 ]

--- a/src/sdk/python/ratel_ai/_native.pyi
+++ b/src/sdk/python/ratel_ai/_native.pyi
@@ -64,6 +64,17 @@ class SkillRegistry:
         metadata: dict[str, list[str]],
         body: str,
     ) -> None: ...
+    def upsert(
+        self,
+        id: str,
+        name: str,
+        description: str,
+        tags: list[str],
+        tools: list[str],
+        metadata: dict[str, list[str]],
+        body: str,
+    ) -> bool: ...
+    def remove(self, skill_id: str) -> bool: ...
     def search(self, query: str, top_k: int) -> list[SkillHit]: ...
     def search_with_origin(self, query: str, top_k: int, origin: str) -> list[SkillHit]: ...
     def search_with_method(

--- a/src/sdk/python/ratel_ai/capabilities.py
+++ b/src/sdk/python/ratel_ai/capabilities.py
@@ -102,6 +102,28 @@ def _build_search_description(has_skills: bool, upstreams: Sequence[UpstreamServ
     )
 
 
+class _LiveDescriptionTool(ExecutableTool):
+    """An `ExecutableTool` whose `description` is recomputed at read time — so a
+    skill catalog hydrated or mutated after construction advertises correctly.
+    NOTE: copying the field (`dataclasses.replace`, `tool.description`) freezes
+    the text at read time; hosts that cache it should resnapshot on
+    `SkillCatalog.on_change`.
+    """
+
+    def __init__(self, describe: Callable[[], str], **kwargs: Any) -> None:
+        self._describe = describe
+        super().__init__(description="", **kwargs)
+
+    @property
+    def description(self) -> str:
+        return self._describe()
+
+    @description.setter
+    def description(self, value: str) -> None:
+        # The dataclass __init__ assigns the placeholder; the live value wins.
+        pass
+
+
 def search_capabilities_tool(
     catalog: ToolCatalog,
     skill_catalog: SkillCatalog | None = None,
@@ -116,7 +138,6 @@ def search_capabilities_tool(
     """
     upstreams = list(upstream_servers or [])
     upstream_by_name = {u.name: u for u in upstreams}
-    has_skills = skill_catalog is not None and skill_catalog.size() > 0
 
     async def execute(input: dict[str, Any]) -> dict[str, Any]:
         query = input["query"]
@@ -197,10 +218,14 @@ def search_capabilities_tool(
 
         return {"tools": {"groups": [groups[n] for n in order]}, "skills": skills}
 
-    return ExecutableTool(
+    def describe() -> str:
+        has_skills = skill_catalog is not None and skill_catalog.size() > 0
+        return _build_search_description(has_skills, upstreams)
+
+    return _LiveDescriptionTool(
+        describe,
         id=SEARCH_CAPABILITIES_ID,
         name=SEARCH_CAPABILITIES_ID,
-        description=_build_search_description(has_skills, upstreams),
         input_schema={
             "type": "object",
             "properties": {

--- a/src/sdk/python/ratel_ai/skill_catalog.py
+++ b/src/sdk/python/ratel_ai/skill_catalog.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from ._native import SkillHit, SkillRegistry
 from .catalog import SearchMethod, SearchOrigin, TraceSinkConfig
@@ -49,6 +49,7 @@ class SkillCatalog:
         self._skills: dict[str, Skill] = {}
         self._method: SearchMethod = method
         self._eager: bool = method in ("semantic", "hybrid")
+        self._change_listeners: list[Callable[[], None]] = []
         if trace is not None:
             self._registry.set_trace_sink(trace.kind, trace.session_id, trace.path)
 
@@ -65,6 +66,56 @@ class SkillCatalog:
         self._skills[skill.id] = skill
         if self._eager:
             self._registry.build_embeddings()
+        self._notify_change()
+
+    def upsert(self, skill: Skill) -> bool:
+        """Register-or-replace by id. Returns `True` when an existing skill was
+        replaced. The path catalog sync uses to hot-reload a changed skill.
+        """
+        replaced = self._registry.upsert(
+            skill.id,
+            skill.name,
+            skill.description,
+            skill.tags,
+            skill.tools,
+            skill.metadata,
+            skill.body,
+        )
+        self._skills[skill.id] = skill
+        if self._eager:
+            self._registry.build_embeddings()
+        self._notify_change()
+        return replaced
+
+    def remove(self, skill_id: str) -> bool:
+        """Remove a skill by id. Returns `True` when something was removed."""
+        removed = self._registry.remove(skill_id)
+        self._skills.pop(skill_id, None)
+        if removed:
+            self._notify_change()
+        return removed
+
+    def on_change(self, listener: Callable[[], None]) -> Callable[[], None]:
+        """Subscribe to catalog mutations (register/upsert/remove). Returns an
+        unsubscribe function. The staleness hook for hosts that cache what the
+        capability tools advertise.
+        """
+        self._change_listeners.append(listener)
+
+        def unsubscribe() -> None:
+            if listener in self._change_listeners:
+                self._change_listeners.remove(listener)
+
+        return unsubscribe
+
+    def _notify_change(self) -> None:
+        for listener in list(self._change_listeners):
+            # A listener is a best-effort observer; its failure must never
+            # break (or roll back) the mutation that triggered it.
+            try:
+                listener()
+            except Exception:
+                pass
 
     def build_embeddings(self) -> None:
         """Pre-compute embeddings for not-yet-embedded skills. See

--- a/src/sdk/python/ratel_ai/source.py
+++ b/src/sdk/python/ratel_ai/source.py
@@ -1,0 +1,61 @@
+"""Catalog-source config seam — the Python mirror of `src/sdk/ts/src/source.ts`.
+
+Pure resolution of where a catalog-source loader pulls from (ADR-0003): explicit
+options beat the `RATEL_URL` / `RATEL_API_KEY` environment; no url anywhere means
+no source (the permanent embedded floor). Loaders (e.g. `ratel-ai-cloud`) consume
+the resolved `SourceConfig`; this module never touches the network.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+__all__ = ["SOURCE_API_KEY_ENV", "SOURCE_URL_ENV", "SourceConfig", "SourceOptions"]
+
+SOURCE_URL_ENV = "RATEL_URL"
+SOURCE_API_KEY_ENV = "RATEL_API_KEY"
+
+
+@dataclass(frozen=True)
+class SourceOptions:
+    """Explicit loader options; any field set here wins over the environment.
+
+    `scope` is an opaque subject selector passed through as `?scope=` (ADR-0010);
+    it is options-only — never read from the environment.
+    """
+
+    url: str | None = None
+    api_key: str | None = None
+    scope: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceConfig:
+    """A resolved catalog source: base URL, Bearer key, and fixed scope."""
+
+    url: str
+    api_key: str | None
+    scope: str | None
+
+
+def resolve_source_config(
+    options: SourceOptions | None = None,
+    env: Mapping[str, str] | None = None,
+) -> SourceConfig | None:
+    """Resolve options + environment into a `SourceConfig`, or `None` when no
+    url is configured anywhere. Pure and env-injectable (the
+    `resolve_otlp_config` pattern) so precedence is testable without patching
+    `os.environ`.
+    """
+    opts = options or SourceOptions()
+    environ = os.environ if env is None else env
+    url = opts.url or environ.get(SOURCE_URL_ENV)
+    if not url:
+        return None
+    return SourceConfig(
+        url=url,
+        api_key=opts.api_key or environ.get(SOURCE_API_KEY_ENV),
+        scope=opts.scope,
+    )

--- a/src/sdk/python/tests/test_capabilities.py
+++ b/src/sdk/python/tests/test_capabilities.py
@@ -290,3 +290,17 @@ def test_search_capabilities_description_mentions_skills_only_when_wired() -> No
     # an empty skill catalog is treated as no skills
     empty = search_capabilities_tool(catalog, SkillCatalog())
     assert "get_skill_content" not in empty.description
+
+
+def test_search_capabilities_description_recomputes_as_the_skill_catalog_mutates() -> None:
+    # Built against an empty skill catalog, read after hydration: the
+    # description must reflect skill presence at read time, not factory time.
+    skills = SkillCatalog()
+    search = search_capabilities_tool(ToolCatalog(), skills)
+    assert "get_skill_content" not in search.description
+
+    skills.upsert(Skill(id="vercel-deploy", name="vercel-deploy", description="Deploy to Vercel."))
+    assert "get_skill_content" in search.description
+
+    skills.remove("vercel-deploy")
+    assert "get_skill_content" not in search.description

--- a/src/sdk/python/tests/test_index.py
+++ b/src/sdk/python/tests/test_index.py
@@ -26,6 +26,10 @@ def test_public_exports_present() -> None:
         "Skill",
         "GET_SKILL_CONTENT_ID",
         "get_skill_content_tool",
+        # catalog-source seam
+        "SourceConfig",
+        "SourceOptions",
+        "resolve_source_config",
     }
     assert expected.issubset(set(ratel_ai.__all__))
     for name in expected:

--- a/src/sdk/python/tests/test_native.py
+++ b/src/sdk/python/tests/test_native.py
@@ -79,3 +79,27 @@ def test_memory_sink_requires_session_id() -> None:
     reg = ToolRegistry()
     with pytest.raises(ValueError, match="session_id"):
         reg.set_trace_sink("memory")
+
+
+def _skill_args(description: str) -> tuple:
+    return ("api-design", "api-design", description, ["api"], [], {}, "# body")
+
+
+def test_skill_registry_upsert_replaces_by_id_and_reports_replacement() -> None:
+    from ratel_ai import SkillRegistry
+
+    reg = SkillRegistry()
+    assert reg.upsert(*_skill_args("REST API design patterns")) is False
+    assert reg.upsert(*_skill_args("GraphQL schema modeling")) is True
+    assert reg.search("GraphQL schema", 5)[0].skill_id == "api-design"
+    assert reg.search("REST patterns", 5) == []
+
+
+def test_skill_registry_remove_drops_the_skill_and_reports_membership() -> None:
+    from ratel_ai import SkillRegistry
+
+    reg = SkillRegistry()
+    reg.register(*_skill_args("REST API design patterns"))
+    assert reg.remove("api-design") is True
+    assert reg.remove("api-design") is False
+    assert reg.search("REST API", 5) == []

--- a/src/sdk/python/tests/test_skill_catalog.py
+++ b/src/sdk/python/tests/test_skill_catalog.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ratel_ai import Skill, SkillCatalog
+from ratel_ai import Skill, SkillCatalog, TraceSinkConfig
 
 
 def _catalog(*skills: Skill) -> SkillCatalog:
@@ -49,3 +49,100 @@ def test_minimal_skill_without_tags_or_body() -> None:
     assert catalog.has("min")
     assert catalog.invoke("min") == ""
     assert catalog.search("minimal", 5)[0].skill_id == "min"
+
+
+_API_DESIGN = Skill(
+    id="api-design",
+    name="api-design",
+    description="REST API design patterns: resource naming, status codes, pagination.",
+    tags=["backend", "api"],
+    body="# API Design\n\nUse nouns for resources.",
+)
+
+
+def test_upsert_replaces_an_existing_skill_and_reindexes_it() -> None:
+    catalog = _catalog(_API_DESIGN)
+
+    replaced = catalog.upsert(
+        Skill(
+            id="api-design",
+            name="api-design",
+            description="GraphQL schema modeling and federation.",
+            tags=["graphql"],
+            body="# GraphQL",
+        )
+    )
+
+    assert replaced is True
+    assert catalog.search("REST pagination", 5) == []
+    assert catalog.search("GraphQL federation", 5)[0].skill_id == "api-design"
+    assert "GraphQL" in catalog.get("api-design").description
+    assert catalog.invoke("api-design") == "# GraphQL"
+
+
+def test_upsert_of_a_new_id_registers_it_and_reports_no_replacement() -> None:
+    catalog = SkillCatalog()
+    assert catalog.upsert(_API_DESIGN) is False
+    assert catalog.has("api-design")
+
+
+def test_remove_drops_the_skill_from_search_and_membership() -> None:
+    catalog = _catalog(_API_DESIGN)
+
+    assert catalog.remove("api-design") is True
+    assert catalog.remove("api-design") is False
+    assert not catalog.has("api-design")
+    assert catalog.search("REST API", 5) == []
+
+
+def test_upsert_and_remove_emit_churn_through_the_catalogs_trace_sink() -> None:
+    # Pins that mutation flows through the registry the sink was bound to in
+    # __init__ — a registry rebuild would silently drop these events.
+    catalog = SkillCatalog(trace=TraceSinkConfig(kind="memory", session_id="t"))
+    catalog.register(_API_DESIGN)
+    catalog.drain_trace_events()
+
+    catalog.upsert(Skill(id="api-design", name="api-design", description="GraphQL modeling."))
+    catalog.remove("api-design")
+
+    kinds = [e["kind"] for e in catalog.drain_trace_events() if e["type"] == "skill_churn"]
+    assert kinds == ["remove", "add", "remove"]
+
+
+def test_on_change_fires_on_register_upsert_remove_until_unsubscribed() -> None:
+    catalog = SkillCatalog()
+    fired = 0
+
+    def listener() -> None:
+        nonlocal fired
+        fired += 1
+
+    unsubscribe = catalog.on_change(listener)
+
+    catalog.register(_API_DESIGN)
+    catalog.upsert(Skill(id="slides", name="slides", description="Build HTML presentations."))
+    catalog.remove("api-design")
+    assert fired == 3
+
+    unsubscribe()
+    catalog.remove("slides")
+    assert fired == 3
+
+
+def test_a_throwing_listener_does_not_break_the_mutation_or_other_listeners() -> None:
+    catalog = SkillCatalog()
+    seen: list[str] = []
+
+    def bad() -> None:
+        raise RuntimeError("listener bug")
+
+    def good() -> None:
+        seen.append("good")
+
+    catalog.on_change(bad)
+    catalog.on_change(good)
+
+    catalog.register(_API_DESIGN)
+
+    assert catalog.has("api-design")
+    assert seen == ["good"]

--- a/src/sdk/python/tests/test_source.py
+++ b/src/sdk/python/tests/test_source.py
@@ -1,0 +1,46 @@
+"""Tests for the catalog-source config seam (`ratel_ai.source`)."""
+
+from ratel_ai.source import SourceConfig, SourceOptions, resolve_source_config
+
+
+def test_resolves_url_and_api_key_from_env() -> None:
+    config = resolve_source_config(
+        env={"RATEL_URL": "https://cloud.ratel.sh", "RATEL_API_KEY": "sk-test"}
+    )
+    assert config == SourceConfig(url="https://cloud.ratel.sh", api_key="sk-test", scope=None)
+
+
+def test_explicit_options_beat_the_environment() -> None:
+    config = resolve_source_config(
+        SourceOptions(url="https://self-hosted.example", api_key="sk-opt"),
+        env={"RATEL_URL": "https://cloud.ratel.sh", "RATEL_API_KEY": "sk-env"},
+    )
+    assert config == SourceConfig(url="https://self-hosted.example", api_key="sk-opt", scope=None)
+
+
+def test_option_url_with_env_api_key_composes() -> None:
+    config = resolve_source_config(
+        SourceOptions(url="https://self-hosted.example"),
+        env={"RATEL_API_KEY": "sk-env"},
+    )
+    assert config == SourceConfig(url="https://self-hosted.example", api_key="sk-env", scope=None)
+
+
+def test_no_url_anywhere_is_the_embedded_floor() -> None:
+    assert resolve_source_config(env={}) is None
+    assert resolve_source_config(SourceOptions(api_key="sk-only"), env={}) is None
+    assert resolve_source_config(env={"RATEL_URL": ""}) is None
+
+
+def test_scope_comes_from_options_only() -> None:
+    config = resolve_source_config(
+        SourceOptions(scope="user:alice"),
+        env={"RATEL_URL": "https://cloud.ratel.sh", "RATEL_SCOPE": "user:bob"},
+    )
+    assert config is not None
+    assert config.scope == "user:alice"
+
+    from_env_only = resolve_source_config(env={"RATEL_URL": "https://cloud.ratel.sh"})
+    assert from_env_only is not None
+    assert from_env_only.api_key is None
+    assert from_env_only.scope is None

--- a/src/sdk/ts/native/src/lib.rs
+++ b/src/sdk/ts/native/src/lib.rs
@@ -225,6 +225,18 @@ pub struct SkillHit {
     pub score: f64,
 }
 
+fn to_core_skill(skill: Skill) -> core::Skill {
+    core::Skill {
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+        tags: skill.tags.unwrap_or_default(),
+        tools: skill.tools.unwrap_or_default(),
+        metadata: skill.metadata.unwrap_or_default(),
+        body: skill.body.unwrap_or_default(),
+    }
+}
+
 #[napi]
 pub struct SkillRegistry {
     inner: core::SkillRegistry,
@@ -244,15 +256,21 @@ impl SkillRegistry {
 
     #[napi]
     pub fn register(&mut self, skill: Skill) {
-        self.inner.register(core::Skill {
-            id: skill.id,
-            name: skill.name,
-            description: skill.description,
-            tags: skill.tags.unwrap_or_default(),
-            tools: skill.tools.unwrap_or_default(),
-            metadata: skill.metadata.unwrap_or_default(),
-            body: skill.body.unwrap_or_default(),
-        });
+        self.inner.register(to_core_skill(skill));
+    }
+
+    /// Register-or-replace by id — see `ratel_ai_core::SkillRegistry::upsert`.
+    /// Returns `true` when an existing skill was replaced.
+    #[napi]
+    pub fn upsert(&mut self, skill: Skill) -> bool {
+        self.inner.upsert(to_core_skill(skill))
+    }
+
+    /// Remove every skill with the id — see `ratel_ai_core::SkillRegistry::remove`.
+    /// Returns `true` when anything was removed.
+    #[napi]
+    pub fn remove(&mut self, skill_id: String) -> bool {
+        self.inner.remove(&skill_id)
     }
 
     #[napi]

--- a/src/sdk/ts/src/capabilities.test.ts
+++ b/src/sdk/ts/src/capabilities.test.ts
@@ -60,6 +60,29 @@ describe("searchCapabilitiesTool", () => {
     expect(SEARCH_CAPABILITIES_ID).toBe("search_capabilities");
   });
 
+  it("advertises the skills bucket as soon as a skill lands after tool creation", async () => {
+    // Async hydration fills the catalog after the tool is built — the
+    // description must be computed at read time, not baked at factory time.
+    const skills = new SkillCatalog();
+    const tool = searchCapabilitiesTool(new ToolCatalog(), skills);
+    expect(tool.description).not.toContain("get_skill_content");
+
+    skills.register(vercelSkill);
+    expect(tool.description).toContain("get_skill_content");
+
+    skills.remove("vercel-deploy");
+    expect(tool.description).not.toContain("get_skill_content");
+  });
+
+  it("upsert into an empty catalog flips the advertised description too", () => {
+    const skills = new SkillCatalog();
+    const tool = searchCapabilitiesTool(new ToolCatalog(), skills);
+    expect(tool.description).not.toContain("get_skill_content");
+
+    skills.upsert(vercelSkill);
+    expect(tool.description).toContain("get_skill_content");
+  });
+
   it("returns tools grouped by server and an empty skills bucket when no skill catalog", async () => {
     const tools = new ToolCatalog();
     tools.register(readFile);

--- a/src/sdk/ts/src/capabilities.ts
+++ b/src/sdk/ts/src/capabilities.ts
@@ -22,10 +22,11 @@ function clampTopK(value: unknown, fallback: number): number {
   return Math.min(value, MAX_TOP_K);
 }
 
-// The discovery prompt the model sees. The skills clause is only included when a
-// non-empty skill catalog is wired in — otherwise the tool would advertise a
+// The discovery prompt the model sees. The skills clause is only included while
+// the wired skill catalog is non-empty — otherwise the tool would advertise a
 // `skills` bucket and `get_skill_content` that don't exist (the result would
-// always be `skills: []`).
+// always be `skills: []`). Recomputed on every read so a catalog hydrated after
+// the tool was built (e.g. by an async source loader) is advertised correctly.
 const SEARCH_INTRO =
   "Discover capabilities beyond the ones already in your direct tool list. Call this BEFORE refusing " +
   "a request, falling back to a generic capability (web fetch, shell, built-in search), or improvising " +
@@ -102,11 +103,13 @@ export function searchCapabilitiesTool(
 ): ExecutableTool {
   const upstreams = opts?.upstreamServers ?? [];
   const upstreamByName = new Map(upstreams.map((u) => [u.name, u]));
-  const hasSkills = skillCatalog !== undefined && skillCatalog.size() > 0;
   return {
     id: SEARCH_CAPABILITIES_ID,
     name: SEARCH_CAPABILITIES_ID,
-    description: buildSearchDescription(hasSkills, opts),
+    get description() {
+      const hasSkills = skillCatalog !== undefined && skillCatalog.size() > 0;
+      return buildSearchDescription(hasSkills, opts);
+    },
     inputSchema: {
       type: "object",
       properties: {

--- a/src/sdk/ts/src/index.ts
+++ b/src/sdk/ts/src/index.ts
@@ -39,6 +39,8 @@ export { registerMcpServer } from "./mcp.js";
 export type { SkillCatalogOptions } from "./skill-catalog.js";
 export { SkillCatalog } from "./skill-catalog.js";
 export { GET_SKILL_CONTENT_ID, getSkillContentTool } from "./skill-tools.js";
+export type { CatalogSourceConfig } from "./source.js";
+export { resolveSourceConfig, SOURCE_API_KEY_ENV, SOURCE_URL_ENV } from "./source.js";
 // OpenTelemetry export of the ratel.*/gen_ai.* funnel. The SDK always emits
 // spans to the active OTel provider; `configureTelemetry` is optional sugar
 // that wires a Ratel-owned OTLP exporter (needs the peer @ratel-ai/telemetry-otlp).

--- a/src/sdk/ts/src/skill-catalog.test.ts
+++ b/src/sdk/ts/src/skill-catalog.test.ts
@@ -66,6 +66,99 @@ describe("SkillCatalog", () => {
   });
 });
 
+describe("SkillCatalog mutation", () => {
+  it("upsert replaces an existing skill and reindexes it", () => {
+    const catalog = new SkillCatalog();
+    catalog.register(apiDesign);
+
+    const replaced = catalog.upsert({
+      id: "api-design",
+      name: "api-design",
+      description: "GraphQL schema modeling and federation.",
+      tags: ["graphql"],
+      body: "# GraphQL",
+    });
+
+    expect(replaced).toBe(true);
+    expect(catalog.search("REST pagination", 5)).toEqual([]);
+    expect(catalog.search("GraphQL federation", 5)[0]?.skillId).toBe("api-design");
+    expect(catalog.get("api-design")?.description).toContain("GraphQL");
+    expect(catalog.invoke("api-design")).toBe("# GraphQL");
+    expect(catalog.size()).toBe(1);
+  });
+
+  it("upsert of a new id registers it and reports no replacement", () => {
+    const catalog = new SkillCatalog();
+    expect(catalog.upsert(apiDesign)).toBe(false);
+    expect(catalog.has("api-design")).toBe(true);
+  });
+
+  it("remove drops the skill from search and membership", () => {
+    const catalog = new SkillCatalog();
+    catalog.register(apiDesign);
+
+    expect(catalog.remove("api-design")).toBe(true);
+    expect(catalog.remove("api-design")).toBe(false);
+    expect(catalog.has("api-design")).toBe(false);
+    expect(catalog.search("REST API", 5)).toEqual([]);
+  });
+
+  it("upsert of an existing id emits skill_churn remove then add", () => {
+    const catalog = new SkillCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    catalog.register(apiDesign);
+    catalog.drainTraceEvents();
+
+    catalog.upsert({ ...apiDesign, description: "GraphQL schema modeling." });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const churn = events.filter((e) => e.type === "skill_churn").map((e) => e.kind);
+    expect(churn).toEqual(["remove", "add"]);
+  });
+
+  it("onChange fires after register/upsert/remove until unsubscribed", () => {
+    const catalog = new SkillCatalog();
+    let fired = 0;
+    const unsubscribe = catalog.onChange(() => {
+      fired += 1;
+    });
+
+    catalog.register(apiDesign);
+    catalog.upsert(slides);
+    catalog.remove("api-design");
+    expect(fired).toBe(3);
+
+    unsubscribe();
+    catalog.remove("frontend-slides");
+    expect(fired).toBe(3);
+  });
+
+  it("onChange does not fire when remove is a no-op", () => {
+    const catalog = new SkillCatalog();
+    let fired = 0;
+    catalog.onChange(() => {
+      fired += 1;
+    });
+
+    catalog.remove("ghost");
+    expect(fired).toBe(0);
+  });
+
+  it("a throwing listener breaks neither the mutation nor the other listeners", () => {
+    const catalog = new SkillCatalog();
+    let laterListenerFired = 0;
+    catalog.onChange(() => {
+      throw new Error("boom");
+    });
+    catalog.onChange(() => {
+      laterListenerFired += 1;
+    });
+
+    expect(() => catalog.register(apiDesign)).not.toThrow();
+    expect(catalog.has("api-design")).toBe(true);
+    expect(laterListenerFired).toBe(1);
+  });
+});
+
 describe("SkillCatalog tracing", () => {
   it("does not capture events under the default noop sink", () => {
     const catalog = new SkillCatalog();

--- a/src/sdk/ts/src/skill-catalog.ts
+++ b/src/sdk/ts/src/skill-catalog.ts
@@ -19,6 +19,7 @@ export interface SkillCatalogOptions {
 export class SkillCatalog {
   private readonly registry: SkillRegistry;
   private readonly skills = new Map<string, Skill>();
+  private readonly changeListeners = new Set<() => void>();
   private readonly method: SearchMethod;
   private readonly eager: boolean;
 
@@ -36,6 +37,56 @@ export class SkillCatalog {
     this.skills.set(skill.id, skill);
     if (this.eager) {
       this.registry.buildEmbeddings();
+    }
+    this.notifyChange();
+  }
+
+  /**
+   * Register-or-replace by id. Returns `true` when an existing skill was
+   * replaced. The path catalog sync uses to hot-reload a changed skill.
+   */
+  upsert(skill: Skill): boolean {
+    const replaced = this.registry.upsert(skill);
+    this.skills.set(skill.id, skill);
+    if (this.eager) {
+      this.registry.buildEmbeddings();
+    }
+    this.notifyChange();
+    return replaced;
+  }
+
+  /** Remove a skill by id. Returns `true` when something was removed. */
+  remove(skillId: string): boolean {
+    const removed = this.registry.remove(skillId);
+    this.skills.delete(skillId);
+    if (removed) {
+      if (this.eager) {
+        this.registry.buildEmbeddings();
+      }
+      this.notifyChange();
+    }
+    return removed;
+  }
+
+  /**
+   * Subscribe to catalog mutations (register/upsert/remove). Returns an
+   * unsubscribe function. The staleness hook for anything that caches a view
+   * of the catalog, e.g. `tools/list_changed` notifications.
+   */
+  onChange(listener: () => void): () => void {
+    this.changeListeners.add(listener);
+    return () => {
+      this.changeListeners.delete(listener);
+    };
+  }
+
+  private notifyChange(): void {
+    for (const listener of this.changeListeners) {
+      try {
+        listener();
+      } catch {
+        // A broken subscriber must not break the mutation or its siblings.
+      }
     }
   }
 

--- a/src/sdk/ts/src/source.test.ts
+++ b/src/sdk/ts/src/source.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveSourceConfig } from "./index.js";
+
+describe("resolveSourceConfig", () => {
+  it("returns undefined with no options and no env — the embedded floor", () => {
+    expect(resolveSourceConfig(undefined, {})).toBeUndefined();
+    expect(resolveSourceConfig({}, {})).toBeUndefined();
+  });
+
+  it("resolves url and apiKey from the env", () => {
+    const config = resolveSourceConfig(undefined, {
+      RATEL_URL: "https://cloud.ratel.sh",
+      RATEL_API_KEY: "rk_env",
+    });
+    expect(config).toEqual({ url: "https://cloud.ratel.sh", apiKey: "rk_env" });
+  });
+
+  it("explicit options beat the env", () => {
+    const config = resolveSourceConfig(
+      { url: "https://self-hosted.example", apiKey: "rk_opt" },
+      { RATEL_URL: "https://cloud.ratel.sh", RATEL_API_KEY: "rk_env" },
+    );
+    expect(config).toEqual({ url: "https://self-hosted.example", apiKey: "rk_opt" });
+  });
+
+  it("mixes an env url with an explicit apiKey (and vice versa)", () => {
+    expect(
+      resolveSourceConfig({ apiKey: "rk_opt" }, { RATEL_URL: "https://cloud.ratel.sh" }),
+    ).toEqual({ url: "https://cloud.ratel.sh", apiKey: "rk_opt" });
+    expect(
+      resolveSourceConfig({ url: "https://self-hosted.example" }, { RATEL_API_KEY: "rk_env" }),
+    ).toEqual({ url: "https://self-hosted.example", apiKey: "rk_env" });
+  });
+
+  it("returns undefined when only an apiKey is available — a key names no source", () => {
+    expect(resolveSourceConfig({ apiKey: "rk_opt" }, { RATEL_API_KEY: "rk_env" })).toBeUndefined();
+  });
+
+  it("passes scope through from options only", () => {
+    const config = resolveSourceConfig({ scope: "alice" }, { RATEL_URL: "https://cloud.ratel.sh" });
+    expect(config).toEqual({ url: "https://cloud.ratel.sh", scope: "alice" });
+  });
+
+  it("omits apiKey and scope when they resolve to nothing", () => {
+    const config = resolveSourceConfig({ url: "https://cloud.ratel.sh" }, {});
+    expect(config).toEqual({ url: "https://cloud.ratel.sh" });
+    expect(config && "apiKey" in config).toBe(false);
+    expect(config && "scope" in config).toBe(false);
+  });
+});

--- a/src/sdk/ts/src/source.ts
+++ b/src/sdk/ts/src/source.ts
@@ -1,0 +1,45 @@
+/**
+ * Catalog-source configuration seam (ADR-0003). A source is a remote catalog
+ * a loader pulls skills from over the frozen protocol/v1 contract; resolution
+ * here only decides *whether* a source is configured and with what
+ * credentials — no loader is selected, no network is touched. Pure and
+ * env-injectable, modeled on `resolveOtlpConfig` in `@ratel-ai/telemetry`.
+ */
+
+// The package compiles without node type definitions; this module-local
+// declaration types the single `process.env` read (node >= 20 per `engines`).
+declare const process: { env: Record<string, string | undefined> };
+
+/** Env var naming the catalog source's base URL. Unset = the embedded floor. */
+export const SOURCE_URL_ENV = "RATEL_URL";
+
+/** Env var holding the source API key, sent as `Authorization: Bearer <key>`. */
+export const SOURCE_API_KEY_ENV = "RATEL_API_KEY";
+
+export interface CatalogSourceConfig {
+  /** Base URL of the catalog source (the loader appends `/v1/catalog`). */
+  url: string;
+  /** API key for `Authorization: Bearer <key>` on every `/v1` request. */
+  apiKey?: string;
+  /** Opaque subject selector, passed through as `?scope=`. Fixed per loader. */
+  scope?: string;
+}
+
+/**
+ * Resolve explicit options + env into a source config, or `undefined` when no
+ * URL is available anywhere — the permanent offline floor: in-process
+ * registration only, byte-identical to a build with no source code paths.
+ * Explicit options beat env; `scope` comes from options only.
+ */
+export function resolveSourceConfig(
+  options?: { url?: string; apiKey?: string; scope?: string },
+  env: Record<string, string | undefined> = process.env,
+): CatalogSourceConfig | undefined {
+  const url = options?.url ?? env[SOURCE_URL_ENV];
+  if (!url) return undefined;
+  const config: CatalogSourceConfig = { url };
+  const apiKey = options?.apiKey ?? env[SOURCE_API_KEY_ENV];
+  if (apiKey !== undefined) config.apiKey = apiKey;
+  if (options?.scope !== undefined) config.scope = options.scope;
+  return config;
+}


### PR DESCRIPTION
Wires the frozen `protocol/v1` catalog-source contract into the SDK and ships the first two pull-sync loaders. Apps keep one API — `search_capabilities` / `invoke_tool` / `get_skill_content` — over two transports: the embedded in-process catalog (the floor), or a remote catalog source selected by `RATEL_URL`. App code is unchanged either way.

New packages: **`@ratel-ai/cloud`** (npm) and **`ratel-ai-cloud`** (PyPI), MIT.

## What's added

**Catalog mutation (core + FFI + SDK).** The skill registry gains `upsert`/`remove` (remove-then-add churn, duplicate-id normalization, dense-cache invalidation on removal/replacement); exposed through both native bindings and as `SkillCatalog.upsert`/`remove` + a change listener in each SDK. Host-registered skills and synced skills coexist — mutation is per-id, never a wholesale snapshot swap.

**Source seam.** `resolveSourceConfig` / `resolve_source_config` reads `RATEL_URL` + `RATEL_API_KEY` (explicit options beat env, pure and injectable). With no URL configured the SDK stays fully in-process — the offline floor is byte-for-byte unchanged.

**Live capability-tool description.** `search_capabilities`'s advertised description is now computed at read time, so skills hydrated asynchronously (e.g. by a loader after startup) are reflected to the model instead of frozen at construction.

**Pull-sync loaders.** Both packages implement the `protocol/v1` client: canonicalizer + scope overlay, conditional GET (ETag / `If-None-Match` → 304), hash-only Bearer auth, `?scope=` subject selector. `SkillSync` keeps an in-memory replica with an ownership rule (skills it synced are its own; host-registered skills are never touched, collisions are surfaced as `conflicts`), a field-level idempotence gate (a resync of unchanged data emits zero churn), a jittered background refresh timer, and a staleness signal (`lastSyncedAt`, `consecutiveFailures`). Auth failures stop the loop; transient failures keep serving the last replica and retry. `ratel-ai-cloud` is stdlib-only (`urllib`), zero runtime deps.

**Conformance.** Both loaders ship an in-process mock source and reproduce **every `protocol/v1` ETag and `If-None-Match` conformance vector** in their own test suites, plus real-catalog integration tests (hydrate → search finds the skill → live description reflects it → source-side removal disappears → host collision survives untouched).

**Release + docs.** Independent per-language release units for the two loaders (`release.yml` / `verify-install.yml` / `publish-rc.sh`), and amendments to ADR-0003 (loader seam, ownership rule, per-id mutation, env vars, scope, replica) and ADR-0005 (dynamic capability-tool advertising).

## Commits

- `feat(core)` — skill registry `upsert`/`remove` + churn + dense-cache invalidation
- `feat(ts-sdk)` / `feat(py-sdk)` — FFI pass-throughs, catalog mutation + change listeners, live capability-tool description, source-config seam
- `feat(ts-cloud)` / `feat(py-cloud)` — the `@ratel-ai/cloud` / `ratel-ai-cloud` loaders + mock sources + conformance/integration tests
- `chore(release)` — cloud loader release units + ADR amendments

Rebased on latest `main` (adopts the gateway → capability-tools rename and the SDK 0.4.0 / telemetry funnel-span changes).

## ⚠️ Draft — not yet verified end to end

Each stage is TDD-green in isolation, and post-rebase the touched packages build + typecheck (TS) and pass (Python SDK: 71 passed). The whole-repo verification pass is still owed:

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` · `cargo fmt --check --all` · `cargo test --workspace`
- [ ] `pnpm -r build && pnpm -r typecheck && pnpm -r lint && pnpm -r test`
- [ ] Python: `ruff check` · `mypy` · `pytest` (SDK + the cloud loader)
- [ ] `node protocol/v1/conformance/verify.mjs`
- [ ] Adversarial review across wire-conformance / cross-language parity / correctness-concurrency

**Cross-repo, sequenced separately:** the managed cloud must serve `GET /v1/catalog` and pass the `protocol/v1` vectors before the loaders point at it for real.

**On merge:** add the two new loader tag prefixes to the release environment tag policy; first publish of each new package is manual (ADR-0008).
