### PR TITLE
fix(sdk): report a failed tool call on both telemetry channels

### DIFF
--- a/src/sdk/python/CHANGELOG.md
+++ b/src/sdk/python/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Fixed
+
+- A tool call that reports failure in its result (`isError`) now closes the `execute_tool` span as `ERROR` and emits `invoke_error`; it previously recorded as a success. Covers both the dict shape and the `mcp` client's `CallToolResult`, whose field is `isError` on mcp 1.x and `is_error` on 2.x.
+
 ## [0.12.0] - 2026-08-21
 
 ### Added

--- a/src/sdk/python/ratel_ai/catalog.py
+++ b/src/sdk/python/ratel_ai/catalog.py
@@ -32,6 +32,7 @@ from .telemetry import (
     SEARCH_TARGET_TOOL,
     RuntimeEventProjection,
     record_catalog_definitions,
+    reports_failure,
     trace_execute_tool,
     trace_search,
     trace_search_async,
@@ -1336,14 +1337,21 @@ class ToolCatalog:
                     result = await result
                 terminal_projection = projection.copy()
                 terminal_projection["event_id"] = new_runtime_event_id()
-                self._registry.record_event(
+                terminal: dict[str, Any] = (
                     {
+                        "type": "invoke_error",
+                        "tool_id": tool_id,
+                        "took_ms": _elapsed_ms(started),
+                        "error": "the tool reported a failure",
+                    }
+                    if reports_failure(result)
+                    else {
                         "type": "invoke_end",
                         "tool_id": tool_id,
                         "took_ms": _elapsed_ms(started),
-                    },
-                    terminal_projection,
+                    }
                 )
+                self._registry.record_event(terminal, terminal_projection)
                 return result
             except asyncio.CancelledError as err:
                 terminal_projection = projection.copy()

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -355,6 +355,11 @@ def _normalize_content(value: Any) -> Any:
     return str(value)
 
 
+def reports_failure(result: Any) -> bool:
+    """MCP reports a failed call in the result (`isError: True`), not by raising."""
+    return isinstance(result, dict) and result.get("isError") is True
+
+
 async def trace_execute_tool(
     tool_id: str,
     args: dict[str, Any],
@@ -388,7 +393,10 @@ async def trace_execute_tool(
             span.set_attribute(GEN_AI_TOOL_CALL_RESULT, _safe_json(result))
         if _capture_content_on_event():
             _add_tool_content_event(tool_id, args, projection["event_id"], result=result)
-        span.set_status(Status(StatusCode.OK))
+        if reports_failure(result):
+            span.set_status(Status(StatusCode.ERROR, "the tool reported a failure"))
+        else:
+            span.set_status(Status(StatusCode.OK))
         return result
 
 

--- a/src/sdk/python/ratel_ai/telemetry.py
+++ b/src/sdk/python/ratel_ai/telemetry.py
@@ -356,8 +356,14 @@ def _normalize_content(value: Any) -> Any:
 
 
 def reports_failure(result: Any) -> bool:
-    """MCP reports a failed call in the result (`isError: True`), not by raising."""
-    return isinstance(result, dict) and result.get("isError") is True
+    """MCP reports a failed call in the result (`isError: True`), not by raising.
+
+    The client returns a `CallToolResult` model, not a dict, and 2.x renamed the
+    field to `is_error` (alias `isError`), hence both shapes and both spellings.
+    """
+    if isinstance(result, dict):
+        return result.get("isError") is True or result.get("is_error") is True
+    return getattr(result, "is_error", None) is True or getattr(result, "isError", None) is True
 
 
 async def trace_execute_tool(

--- a/src/sdk/python/tests/test_catalog.py
+++ b/src/sdk/python/tests/test_catalog.py
@@ -673,6 +673,19 @@ async def test_invoke_emits_start_then_end_telemetry() -> None:
     assert "took_ms" in events[1]
 
 
+async def test_invoke_emits_invoke_error_when_the_tool_reports_a_failure() -> None:
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="s"))
+    await catalog.register(
+        _read_file_tool(
+            lambda args: {"isError": True, "content": [{"type": "text", "text": "boom"}]}
+        )
+    )
+    catalog.drain_trace_events()
+    await catalog.invoke("read_file", {"path": "/a"})
+    types = [e["type"] for e in catalog.drain_trace_events()]
+    assert types == ["invoke_start", "invoke_error"]
+
+
 async def test_invoke_emits_error_telemetry_and_reraises() -> None:
     def boom(args):
         raise RuntimeError("kaboom")

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -135,6 +135,48 @@ def _paginated_probe_server() -> Any:
     return server
 
 
+def _failing_probe_server() -> Any:
+    """Server whose one tool reports failure in the result (`isError`), without raising."""
+    tools = [types.Tool(name="boom", description="always fails", inputSchema={"type": "object"})]
+    failure = types.CallToolResult(
+        content=[types.TextContent(type="text", text="boom")],
+        isError=True,
+    )
+
+    if _mcp_major_version() >= 2:
+        from mcp.server.lowlevel.server import Server
+
+        async def on_list_tools(
+            _ctx: Any, _params: types.PaginatedRequestParams | None
+        ) -> types.ListToolsResult:
+            return types.ListToolsResult(tools=tools)
+
+        async def on_call_tool(
+            _ctx: Any, _params: types.CallToolRequestParams
+        ) -> types.CallToolResult:
+            return failure
+
+        return Server(
+            "ratel-failure-probe",
+            on_list_tools=on_list_tools,
+            on_call_tool=on_call_tool,
+        )
+
+    from mcp.server import Server
+
+    server = Server("ratel-failure-probe")
+
+    @server.list_tools()
+    async def handle_list_tools(request: types.ListToolsRequest) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=tools)
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict | None) -> types.CallToolResult:
+        return failure
+
+    return server
+
+
 class _FakeTool:
     def __init__(self, name, description, input_schema):
         self.name = name
@@ -561,3 +603,20 @@ async def test_register_mcp_server_paginated_list_tools_real_client_session() ->
 
     register_events = [e for e in catalog.drain_trace_events() if e["type"] == "upstream_register"]
     assert register_events[0]["tool_count"] == 3
+
+
+async def test_invoke_emits_invoke_error_when_a_real_mcp_tool_reports_failure() -> None:
+    """MCP signals failure in the result, and the real client returns a model, not a dict."""
+    pytest.importorskip("mcp", reason="install ratel-ai[mcp] to run real MCP session tests")
+
+    server = _failing_probe_server()
+    catalog = ToolCatalog(trace=TraceSinkConfig(kind="memory", session_id="mcp-fail"))
+    async with _memory_client_session(server) as session:
+        await register_mcp_server(catalog, name="demo", session=session)
+        catalog.drain_trace_events()
+        await catalog.invoke("demo__boom", {})
+
+    # The call succeeds at the protocol level; only the body reports the failure.
+    emitted = [e["type"] for e in catalog.drain_trace_events()]
+    assert "invoke_error" in emitted
+    assert "invoke_end" not in emitted

--- a/src/sdk/python/tests/test_telemetry.py
+++ b/src/sdk/python/tests/test_telemetry.py
@@ -118,6 +118,27 @@ async def test_execute_tool_span_attributes(exporter: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_span_is_error_when_the_tool_reports_a_failure(
+    exporter: Any,
+) -> None:
+    catalog = ToolCatalog()
+    await catalog.register(
+        ExecutableTool(
+            id="failing_tool",
+            name="failing_tool",
+            description="Reports a failure in its result instead of raising.",
+            input_schema={"properties": {}},
+            output_schema={"properties": {}},
+            execute=lambda args: {"isError": True, "content": [{"type": "text", "text": "boom"}]},
+        )
+    )
+    await catalog.invoke("failing_tool", {})
+
+    spans = _spans_named(exporter, "execute_tool failing_tool")
+    assert spans[0].status.status_code == StatusCode.ERROR
+
+
+@pytest.mark.asyncio
 async def test_search_span_shares_runtime_event_id(exporter: Any) -> None:
     catalog = ToolCatalog()
     skills = SkillCatalog()

--- a/src/sdk/python/tests/test_telemetry.py
+++ b/src/sdk/python/tests/test_telemetry.py
@@ -139,6 +139,33 @@ async def test_execute_tool_span_is_error_when_the_tool_reports_a_failure(
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_span_is_error_on_the_mcp_result_model(exporter: Any) -> None:
+    """The span channel reads the failure off a `CallToolResult`, not only off a dict."""
+    pytest.importorskip("mcp", reason="install ratel-ai[mcp] to run MCP result-shape tests")
+    from mcp import types
+
+    failure = types.CallToolResult(
+        content=[types.TextContent(type="text", text="boom")],
+        isError=True,
+    )
+    catalog = ToolCatalog()
+    await catalog.register(
+        ExecutableTool(
+            id="failing_model_tool",
+            name="failing_model_tool",
+            description="Returns the result model an mcp client hands back on a failed call.",
+            input_schema={"properties": {}},
+            output_schema={"properties": {}},
+            execute=lambda args: failure,
+        )
+    )
+    await catalog.invoke("failing_model_tool", {})
+
+    spans = _spans_named(exporter, "execute_tool failing_model_tool")
+    assert spans[0].status.status_code == StatusCode.ERROR
+
+
+@pytest.mark.asyncio
 async def test_search_span_shares_runtime_event_id(exporter: Any) -> None:
     catalog = ToolCatalog()
     skills = SkillCatalog()

--- a/src/sdk/ts/CHANGELOG.md
+++ b/src/sdk/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Fixed
+
+- A tool call that reports failure in its result (`isError`) now closes the `execute_tool` span as `ERROR` and emits `invoke_error`; it previously recorded as a success.
+
 ## [0.12.0] - 2026-08-21
 
 ### Added

--- a/src/sdk/ts/src/catalog.test.ts
+++ b/src/sdk/ts/src/catalog.test.ts
@@ -694,6 +694,23 @@ describe("ToolCatalog tracing", () => {
     expect(JSON.stringify(catalog.drainTraceEvents())).not.toContain("tenant-secret");
   });
 
+  it("emits invoke_error when the tool reports a failure in its result", async () => {
+    const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
+    await catalog.register({
+      ...readFile,
+      id: "reports_failure",
+      execute: async () => ({ isError: true, content: [{ type: "text", text: "boom" }] }),
+    });
+    catalog.drainTraceEvents();
+
+    await catalog.invoke("reports_failure", { path: "/x" });
+
+    const events = catalog.drainTraceEvents() as Array<Record<string, unknown>>;
+    const types = events.map((e) => e.type);
+    expect(types).toContain("invoke_error");
+    expect(types).not.toContain("invoke_end");
+  });
+
   it("emits invoke_error when the executor throws and re-throws to the caller", async () => {
     const catalog = new ToolCatalog({ trace: { kind: "memory", sessionId: "t" } });
     await catalog.register({

--- a/src/sdk/ts/src/catalog.ts
+++ b/src/sdk/ts/src/catalog.ts
@@ -18,6 +18,7 @@ import {
   argsSizeBytes,
   errorMessage,
   type RuntimeEventProjection,
+  reportsFailure,
   traceExecuteTool,
   traceSearch,
   traceSearchAsync,
@@ -892,7 +893,11 @@ export function runToolInvocation<T>(
     );
     const started = Date.now();
 
-    const succeed = (_result: unknown): void => {
+    const succeed = (result: unknown): void => {
+      if (reportsFailure(result)) {
+        reject(new Error("the tool reported a failure"));
+        return;
+      }
       catalog.recordEvent(
         {
           type: "invoke_end",

--- a/src/sdk/ts/src/telemetry.test.ts
+++ b/src/sdk/ts/src/telemetry.test.ts
@@ -583,6 +583,20 @@ describe("execute_tool span", () => {
     expect(span.status.code).toBe(1);
   });
 
+  it("marks the span ERROR when the tool reports a failure in its result", async () => {
+    const catalog = new ToolCatalog();
+    await catalog.register({
+      ...readFile,
+      id: "failing_tool",
+      execute: async () => ({ isError: true, content: [{ type: "text", text: "boom" }] }),
+    });
+
+    await catalog.invoke("failing_tool", {});
+
+    const [span] = spansNamed("execute_tool failing_tool");
+    expect(span.status.code).toBe(2); // ERROR
+  });
+
   it("marks an AsyncIterable span ERROR when iteration throws", async () => {
     const catalog = new ToolCatalog();
     await catalog.register({

--- a/src/sdk/ts/src/telemetry.ts
+++ b/src/sdk/ts/src/telemetry.ts
@@ -734,6 +734,18 @@ export function upstreamFromToolId(toolId: string): string | undefined {
   return toolId.slice(0, idx);
 }
 
+/**
+ * MCP reports a failed call in the result (`isError: true`), not by throwing.
+ * @internal
+ */
+export function reportsFailure(result: unknown): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    (result as { isError?: unknown }).isError === true
+  );
+}
+
 /** Close a span in the failure path: record the exception + ERROR status. */
 function fail(span: Span, err: unknown): void {
   if (err instanceof Error) span.recordException(err);
@@ -770,7 +782,11 @@ export function traceExecuteTool<T>(
         if (captureContentOnEvent()) {
           addToolContentEvent(toolId, args, activeContext, projection.eventId, { value: result });
         }
-        span.setStatus({ code: SpanStatusCode.OK });
+        span.setStatus(
+          reportsFailure(result)
+            ? { code: SpanStatusCode.ERROR, message: "the tool reported a failure" }
+            : { code: SpanStatusCode.OK },
+        );
         span.end();
       };
       const reject = (err: unknown): void => {


### PR DESCRIPTION
## Problem

MCP reports a failed tool call in the result (`isError: true`), not by raising an error. 

Both telemetry channels treated only a thrown exception as a failure:

- `traceExecuteTool` set the `execute_tool` span to `OK` for any return that did not throw
- `runToolInvocation` emitted `invoke_end` for those same returns

So a failed call and a successful one were recorded identically, and the dashboard's error rate could not report tool failures at all.

## Solution

A shared `reportsFailure` predicate, exported `@internal` from the telemetry module so both channels agree on what counts as a failure. The span now closes as `ERROR`, and the runtime event becomes `invoke_error` through the existing `reject` path, so no new event type is introduced and nothing downstream needs updating.

Applied to both the TypeScript and Python SDKs.

The failure text is generic (`the tool reported a failure`) because result content sits behind the content-capture gate.

## Notes

The other four unconditional `set_status(...OK)` calls in `ratel_ai/telemetry.py` were checked and do not need this: `trace_search`, `trace_search_async`, `trace_skill_load` and `trace_upstream_register` do not execute tools, so the `isError` convention never reaches them.