### PR TITLE
fix(sdk): resolve handler annotations in the paginated MCP test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,10 +417,12 @@ jobs:
       # `mcp` is installed unpinned and currently resolves to 2.x, so the 1.x-only
       # code path in `_paginated_probe_server` is never hit. `pyproject.toml` allows
       # mcp>=1.0; re-run the suite on 1.x to keep that retro-compatible path verified.
+      # Then restore the resolved version; later steps share this venv.
       - name: Test backwards compatibility with mcp 1.x
         run: |
           uv pip install --python .venv 'mcp<2'
           .venv/bin/pytest
+          uv pip install --python .venv 'mcp>=2'
       # Python 3.9 floor (requires-python >=3.9; ADR-0006 ships cp39 abi3 wheels). The
       # suite above runs on 3.11 only, and the AST guard (tests/test_py39_compat.py)
       # catches just the PEP-604 class of import breakage — stdlib/typing drift (e.g.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,13 @@ jobs:
         run: .venv/bin/mypy ratel_ai
       - name: Test
         run: .venv/bin/pytest
+      # `mcp` is installed unpinned and currently resolves to 2.x, so the 1.x-only
+      # code path in `_paginated_probe_server` is never hit. `pyproject.toml` allows
+      # mcp>=1.0; re-run the suite on 1.x to keep that retro-compatible path verified.
+      - name: Test backwards compatibility with mcp 1.x
+        run: |
+          uv pip install --python .venv 'mcp<2'
+          .venv/bin/pytest
       # Python 3.9 floor (requires-python >=3.9; ADR-0006 ships cp39 abi3 wheels). The
       # suite above runs on 3.11 only, and the AST guard (tests/test_py39_compat.py)
       # catches just the PEP-604 class of import breakage — stdlib/typing drift (e.g.

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -16,6 +16,11 @@ from typing import Any
 
 import pytest
 
+try:  # module scope so get_type_hints can resolve the handler annotations below
+    from mcp import types
+except ImportError:
+    types = None  # type: ignore[assignment]
+
 from ratel_ai import (
     EmbedderError,
     McpToolsListError,

--- a/src/sdk/python/tests/test_mcp.py
+++ b/src/sdk/python/tests/test_mcp.py
@@ -79,7 +79,6 @@ async def _memory_client_session(server: Any) -> AsyncGenerator[Any, None]:
 def _paginated_probe_server() -> Any:
     """Server that returns two pages of tools/list (decorator API on 1.x, handlers on 2.x)."""
     if _mcp_major_version() >= 2:
-        import mcp_types as types
         from mcp.server.lowlevel.server import Server
 
         tools = [
@@ -111,7 +110,6 @@ def _paginated_probe_server() -> Any:
             on_call_tool=on_call_tool,
         )
 
-    from mcp import types
     from mcp.server import Server
 
     server = Server("ratel-pagination-probe")


### PR DESCRIPTION
## Problem

Test `tests/test_mcp.py::test_register_mcp_server_paginated_list_tools_real_client_session` fails against mcp 1.28 with the following error: 

```
handle_list_tools() missing 1 required positional argument: 'request'
```

The file uses `from __future__ import annotations`, so annotations are strings evaluated at runtime. The 1.x handler is annotated with `types`, which is imported inside `_paginated_probe_server` and is therefore not a module global. `get_type_hints` raises `NameError`, and mcp's `create_call_wrapper` catches that and falls back to the old handler style, calling the handler with no arguments.

`pyproject.toml` pins `mcp>=1.0` with no upper bound, so a newer mcp introduced the two-style handler dispatch that exposes this.

## Solution

Import the module at module scope so `get_type_hints` can resolve the annotations. The handler signature is unchanged. The import is guarded because the suite also runs without mcp installed.

Only `list_tools` is affected: `call_tool` does not go through `create_call_wrapper`, and the TypeScript SDK registers handlers with `setRequestHandler`, which always passes the request.

Added CI step to run the tests using `mcp 1.x`, to ensure retro-compatibility in the future.