### PR TITLE
docs: point contributors at main, not the removed revamp branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,8 @@ CI (`.github/workflows/ci.yml`) runs all of the above on every PR through the si
 
 ## Branching
 
-- `main` — stable
-- `revamp` — v1 line, current development target until cutover
-- Branch off `revamp` for new work; PR back into `revamp`
+- `main` — stable, and the current development target
+- Branch off `main` for new work; PR back into `main`
 
 ## Backend before frontend
 


### PR DESCRIPTION
CONTRIBUTING.md sends new contributors to a branch that no longer exists.

    - `revamp` — v1 line, current development target until cutover
    - Branch off `revamp` for new work; PR back into `revamp`

`git ls-remote --heads origin` lists 30 branches and there is no `revamp` among them, only an unrelated `readme/seo-revamp`. `main` is the default branch, and the last ten merged PRs all target `main`, so the cutover the line anticipates has already happened.

Following the guide as written means branching off something that isn't there. #133 targeted `main` and got it right, but only by ignoring this section.

Updated to say what the repo does now. Docs only, no code touched.
